### PR TITLE
Update upload-artifact action, give artifact unique name

### DIFF
--- a/.github/actions/cleanup/action.yml
+++ b/.github/actions/cleanup/action.yml
@@ -8,9 +8,9 @@ inputs:
 runs:
   steps:
     - name: Upload profiles
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: profile
+        name: profile-${{github.run_id}}
         path: .profile/
     - name: Shutdown Bazel
       if: inputs.cache-write == 'true'


### PR DESCRIPTION
upload-artifact@v3 became deprecated Jan 31, 2025, we need to update to v4. V4 requires artifacts to have unique name.

Notice
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Breaking changes
https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes