### PR TITLE
Add shipment document download endpoint

### DIFF
--- a/redo/api-schema/src/openapi.yaml
+++ b/redo/api-schema/src/openapi.yaml
@@ -58,6 +58,8 @@ paths:
   /stores/{storeId}/returns: { $ref: path/returns.path.yaml }
   /stores/{storeId}/shipments/buy: { $ref: path/shipment-buy.path.yaml }
   /stores/{storeId}/shipments/rates: { $ref: path/shipment-rates.path.yaml }
+  /stores/{storeId}/shipments/{shipmentId}/documents/{documentType}:
+    { $ref: path/shipment-document.path.yaml }
   /stores/{storeId}/webhooks: { $ref: path/webhooks.path.yaml }
   /webhooks/{webhookId}: { $ref: path/webhook.path.yaml }
   /webhooks/{webhookId}/replay: { $ref: path/webhook-replay.path.yaml }

--- a/redo/api-schema/src/param/document-type.param.yaml
+++ b/redo/api-schema/src/param/document-type.param.yaml
@@ -1,0 +1,6 @@
+description: Type of document to download
+in: path
+name: documentType
+required: true
+schema:
+  $ref: ../schema/shipment-document-type.schema.yaml

--- a/redo/api-schema/src/param/shipment-id.param.yaml
+++ b/redo/api-schema/src/param/shipment-id.param.yaml
@@ -1,0 +1,7 @@
+description: Shipment ID
+in: path
+name: shipmentId
+required: true
+schema:
+  example: 67c7e87a2c8c262c0ddc9861
+  type: string

--- a/redo/api-schema/src/path/shipment-document.path.yaml
+++ b/redo/api-schema/src/path/shipment-document.path.yaml
@@ -1,0 +1,31 @@
+description: Download shipment document.
+get:
+  description: Get a shipment document (label, commercial invoice, etc).
+  operationId: Shipment document download
+  parameters:
+    - { $ref: ../param/shipment-id.param.yaml }
+    - { $ref: ../param/document-type.param.yaml }
+  responses:
+    "200":
+      content:
+        application/pdf:
+          schema:
+            format: binary
+            type: string
+        image/png:
+          schema:
+            format: binary
+            type: string
+      description: Success
+    default:
+      content:
+        application/problem+json:
+          schema: { $ref: ../schema/error.schema.yaml }
+      description: Error
+  security:
+    - Bearer: []
+  summary: Download shipment document
+  tags: [Shipping]
+parameters:
+  - { $ref: ../param/store-id.param.yaml }
+summary: Shipment Document


### PR DESCRIPTION
- Created a new API endpoint for downloading shipment documents
- Added path parameters for shipmentId and documentType
- Endpoint supports both PDF and PNG document formats
- Added to the OpenAPI spec with store-scoped path

🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>