### PR TITLE
RETCO-6768: Adding the internalCreatedByName to the public docs

### DIFF
--- a/redo/api-schema/src/schema/return-read.schema.yaml
+++ b/redo/api-schema/src/schema/return-read.schema.yaml
@@ -101,6 +101,10 @@ properties:
     examples: [64df65d4c5a4ca3eff4b4e43]
     title: Identifier
     type: string
+  internalCreatedByName:
+    description: Name of the internal team member who created this return
+    title: Internal Created By Name
+    type: string
   items:
     description: Return items
     items:


### PR DESCRIPTION
If it is merchant created then it will have the name of the internal member who created it. Request from Kustomer so they can keep track of internal members who create returns