### PR TITLE
RETCO-7004: Adding params to returns list

### DIFF
--- a/redo/api-schema/src/param/provider-order-name.yaml
+++ b/redo/api-schema/src/param/provider-order-name.yaml
@@ -1,0 +1,6 @@
+description: Provider specific order name
+in: query
+name: provider_order_name
+schema:
+  example: XYZ1025
+  type: string

--- a/redo/api-schema/src/param/shopify-order-name.yaml
+++ b/redo/api-schema/src/param/shopify-order-name.yaml
@@ -1,0 +1,6 @@
+description: Shopify specific order name
+in: query
+name: shopify_order_name
+schema:
+  example: XYZ1025
+  type: string

--- a/redo/api-schema/src/path/returns.path.yaml
+++ b/redo/api-schema/src/path/returns.path.yaml
@@ -7,6 +7,8 @@ get:
     - { $ref: ../param/page-size.param.yaml }
     - { $ref: ../param/updated-at-max.param.yaml }
     - { $ref: ../param/updated-at-min.param.yaml }
+    - { $ref: ../param/shopify-order-name.yaml }
+    - { $ref: ../param/provider-order-name.yaml }
   responses:
     "200":
       content:


### PR DESCRIPTION
Adding shopify_order_name and provider_order_name to the returns list