### PR TITLE
Add fulfillment location fields to return shipments and items

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -1035,6 +1035,12 @@ components:
                 required:
                   - amount
                 type: object
+              shipmentGroupIds:
+                description: IDs of the shipment groups this return item belongs to
+                items:
+                  type: string
+                title: Shipment Group IDs
+                type: array
               sku:
                 description: Product SKU
                 type: string
@@ -1195,9 +1201,23 @@ components:
           description: Carrier code
           title: Carrier
           type: string
+        externalLocationId:
+          description: External location ID for the destination of this shipment
+          title: External Location ID
+          type: string
+        itemIds:
+          description: IDs of the return items included in this shipment
+          items:
+            type: string
+          title: Item IDs
+          type: array
         postageLabel:
           description: Postage label URL
           title: Postage Label
+          type: string
+        shipmentGroupId:
+          description: ID of the shipment group this shipment belongs to
+          title: Shipment Group ID
           type: string
         status:
           description: Status of shipment

--- a/redo/api-schema/src/schema/return-read.schema.yaml
+++ b/redo/api-schema/src/schema/return-read.schema.yaml
@@ -155,6 +155,12 @@ properties:
           description:
             Whether this is a green return (no physical return required)
           type: boolean
+        shipmentGroupIds:
+          description: IDs of the shipment groups this return item belongs to
+          items:
+            type: string
+          title: Shipment Group IDs
+          type: array
         id:
           description: Return item ID.
           title: ID

--- a/redo/api-schema/src/schema/return-shipment.schema.yaml
+++ b/redo/api-schema/src/schema/return-shipment.schema.yaml
@@ -33,5 +33,19 @@ properties:
     description: Postage label URL
     title: Postage Label
     type: string
+  shipmentGroupId:
+    description: ID of the shipment group this shipment belongs to
+    title: Shipment Group ID
+    type: string
+  itemIds:
+    description: IDs of the return items included in this shipment
+    items:
+      type: string
+    title: Item IDs
+    type: array
+  externalLocationId:
+    description: External location ID for the destination of this shipment
+    title: External Location ID
+    type: string
 title: Return Shipment
 type: object


### PR DESCRIPTION
Add shipmentGroupId, itemIds, and externalLocationId to return shipments to support multi-location fulfillment routing. Add shipmentGroupIds to return items to track which shipment groups each item belongs to.

This matches the schema changes from redo/redo#28591.

🤖 Generated with [Claude Code](https://claude.com/claude-code)