### PR TITLE
Add OpenAPI schema for create RMA endpoint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
           git commit -m "chore: regenerate openapi.yaml from source files"
           git push origin HEAD
       - name: Test OpenAPI specification
-        run: bazel test tools/openapi:validate_test --test_output=errors
+        run: bazel test tools/openapi:validate_test --test_output=errors --test_env=PATH
       - if: always()
         name: Clean up
         uses: ./.github/actions/cleanup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
           git commit -m "chore: regenerate openapi.yaml from source files"
           git push origin HEAD
       - name: Test OpenAPI specification
-        run: bazel test tools/openapi:validate_test --test_output=errors --test_env=PATH
+        run: bazel test tools/openapi:validate_test --test_output=errors
       - if: always()
         name: Clean up
         uses: ./.github/actions/cleanup

--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -2093,8 +2093,6 @@ paths:
       - $ref: '#/components/parameters/return-id.param'
     post:
       description: |
-        **BETA**: This endpoint is in beta and subject to change.
-
         Trigger RMA creation for a return across configured integrations.
       operationId: Return create RMA
       responses:

--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -2087,6 +2087,67 @@ paths:
       tags:
         - Returns
     summary: Process return
+  /returns/{returnId}/rmas:
+    description: Create RMA for a return.
+    parameters:
+      - $ref: '#/components/parameters/return-id.param'
+    post:
+      description: |
+        **BETA**: This endpoint is in beta and subject to change.
+
+        Trigger RMA creation for a return across configured integrations.
+      operationId: Return create RMA
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  results:
+                    description: RMA creation results per integration
+                    items:
+                      properties:
+                        errorCode:
+                          description: Error code if RMA creation failed
+                          nullable: true
+                          type: string
+                        errorMessage:
+                          description: Error message if RMA creation failed
+                          nullable: true
+                          type: string
+                        integration:
+                          description: Name of the integration
+                          type: string
+                        successful:
+                          description: Whether RMA creation was successful
+                          type: boolean
+                      required:
+                        - integration
+                        - successful
+                      type: object
+                    type: array
+                required:
+                  - results
+                type: object
+          description: RMA creation completed
+        '404':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/error.schema'
+          description: Return not found
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/error.schema'
+          description: Error
+      security:
+        - Bearer: []
+      summary: Create RMA
+      tags:
+        - Returns
+    summary: Create RMA for a return
   /returns/{returnId}/status:
     description: Return status.
     get:

--- a/redo/api-schema/src/openapi.yaml
+++ b/redo/api-schema/src/openapi.yaml
@@ -47,6 +47,7 @@ paths:
   /returns/{returnId}: { $ref: path/return.path.yaml }
   /returns/{returnId}/comments: { $ref: path/return-comments.path.yaml }
   /returns/{returnId}/process: { $ref: path/return-process.path.yaml }
+  /returns/{returnId}/rmas: { $ref: path/return-create-rma.path.yaml }
   /returns/{returnId}/status: { $ref: path/return-status.path.yaml }
   /stores/{storeId}/admin: { $ref: path/admin.path.yaml }
   /stores/{storeId}/checkout-buttons-ui:

--- a/redo/api-schema/src/path/return-create-rma.path.yaml
+++ b/redo/api-schema/src/path/return-create-rma.path.yaml
@@ -1,0 +1,57 @@
+description: Create RMA for a return.
+parameters:
+  - { $ref: ../param/return-id.param.yaml }
+post:
+  description: |
+    **BETA**: This endpoint is in beta and subject to change.
+
+    Trigger RMA creation for a return across configured integrations.
+  operationId: Return create RMA
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            properties:
+              results:
+                description: RMA creation results per integration
+                items:
+                  properties:
+                    errorCode:
+                      description: Error code if RMA creation failed
+                      nullable: true
+                      type: string
+                    errorMessage:
+                      description: Error message if RMA creation failed
+                      nullable: true
+                      type: string
+                    integration:
+                      description: Name of the integration
+                      type: string
+                    successful:
+                      description: Whether RMA creation was successful
+                      type: boolean
+                  required:
+                    - integration
+                    - successful
+                  type: object
+                type: array
+            required:
+              - results
+            type: object
+      description: RMA creation completed
+    "404":
+      content:
+        application/problem+json:
+          schema: { $ref: ../schema/error.schema.yaml }
+      description: Return not found
+    default:
+      content:
+        application/problem+json:
+          schema: { $ref: ../schema/error.schema.yaml }
+      description: Error
+  security:
+    - Bearer: []
+  summary: Create RMA
+  tags: [Returns]
+summary: Create RMA for a return

--- a/redo/api-schema/src/path/return-create-rma.path.yaml
+++ b/redo/api-schema/src/path/return-create-rma.path.yaml
@@ -3,8 +3,6 @@ parameters:
   - { $ref: ../param/return-id.param.yaml }
 post:
   description: |
-    **BETA**: This endpoint is in beta and subject to change.
-
     Trigger RMA creation for a return across configured integrations.
   operationId: Return create RMA
   responses:


### PR DESCRIPTION
## Summary
- Adds `POST /returns/{returnId}/rmas` OpenAPI path definition for creating RMAs via the public API
- Follows the existing pattern used by other return endpoints (e.g., `/returns/{returnId}/process`)
- Operation ID: `Return create RMA`, tagged under `Returns`
<img width="1741" height="1326" alt="Screenshot 2026-02-17 at 2 57 57 PM" src="https://github.com/user-attachments/assets/1af489e7-2e87-4870-82c3-27d204d548e2" />

## Test plan
- [x] `bazel run openapi_gen` generates successfully
- [x] `bazel run docs -- openapi-check api-schema/openapi.yaml` validates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)