### PR TITLE
Rename create RMA endpoint to create external RMA

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -2005,6 +2005,65 @@ paths:
       tags:
         - Returns
     summary: Return comment
+  /returns/{returnId}/external-rmas:
+    description: Create external RMA for a return.
+    parameters:
+      - $ref: '#/components/parameters/return-id.param'
+    post:
+      description: |
+        Trigger external RMA creation for a return across configured integrations.
+      operationId: Return create external RMA
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  results:
+                    description: RMA creation results per integration
+                    items:
+                      properties:
+                        errorCode:
+                          description: Error code if RMA creation failed
+                          nullable: true
+                          type: string
+                        errorMessage:
+                          description: Error message if RMA creation failed
+                          nullable: true
+                          type: string
+                        integration:
+                          description: Name of the integration
+                          type: string
+                        successful:
+                          description: Whether RMA creation was successful
+                          type: boolean
+                      required:
+                        - integration
+                        - successful
+                      type: object
+                    type: array
+                required:
+                  - results
+                type: object
+          description: RMA creation completed
+        '404':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/error.schema'
+          description: Return not found
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/error.schema'
+          description: Error
+      security:
+        - Bearer: []
+      summary: Create external RMA
+      tags:
+        - Returns
+    summary: Create external RMA for a return
   /returns/{returnId}/process:
     description: Process return.
     parameters:
@@ -2087,65 +2146,6 @@ paths:
       tags:
         - Returns
     summary: Process return
-  /returns/{returnId}/rmas:
-    description: Create RMA for a return.
-    parameters:
-      - $ref: '#/components/parameters/return-id.param'
-    post:
-      description: |
-        Trigger RMA creation for a return across configured integrations.
-      operationId: Return create RMA
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  results:
-                    description: RMA creation results per integration
-                    items:
-                      properties:
-                        errorCode:
-                          description: Error code if RMA creation failed
-                          nullable: true
-                          type: string
-                        errorMessage:
-                          description: Error message if RMA creation failed
-                          nullable: true
-                          type: string
-                        integration:
-                          description: Name of the integration
-                          type: string
-                        successful:
-                          description: Whether RMA creation was successful
-                          type: boolean
-                      required:
-                        - integration
-                        - successful
-                      type: object
-                    type: array
-                required:
-                  - results
-                type: object
-          description: RMA creation completed
-        '404':
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/error.schema'
-          description: Return not found
-        default:
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/error.schema'
-          description: Error
-      security:
-        - Bearer: []
-      summary: Create RMA
-      tags:
-        - Returns
-    summary: Create RMA for a return
   /returns/{returnId}/status:
     description: Return status.
     get:

--- a/redo/api-schema/src/openapi.yaml
+++ b/redo/api-schema/src/openapi.yaml
@@ -47,7 +47,7 @@ paths:
   /returns/{returnId}: { $ref: path/return.path.yaml }
   /returns/{returnId}/comments: { $ref: path/return-comments.path.yaml }
   /returns/{returnId}/process: { $ref: path/return-process.path.yaml }
-  /returns/{returnId}/rmas: { $ref: path/return-create-rma.path.yaml }
+  /returns/{returnId}/external-rmas: { $ref: path/return-create-external-rma.path.yaml }
   /returns/{returnId}/status: { $ref: path/return-status.path.yaml }
   /stores/{storeId}/admin: { $ref: path/admin.path.yaml }
   /stores/{storeId}/checkout-buttons-ui:

--- a/redo/api-schema/src/path/return-create-external-rma.path.yaml
+++ b/redo/api-schema/src/path/return-create-external-rma.path.yaml
@@ -1,10 +1,10 @@
-description: Create RMA for a return.
+description: Create external RMA for a return.
 parameters:
   - { $ref: ../param/return-id.param.yaml }
 post:
   description: |
-    Trigger RMA creation for a return across configured integrations.
-  operationId: Return create RMA
+    Trigger external RMA creation for a return across configured integrations.
+  operationId: Return create external RMA
   responses:
     "200":
       content:
@@ -50,6 +50,6 @@ post:
       description: Error
   security:
     - Bearer: []
-  summary: Create RMA
+  summary: Create external RMA
   tags: [Returns]
-summary: Create RMA for a return
+summary: Create external RMA for a return


### PR DESCRIPTION
## Summary
- Renames the API endpoint path from `/returns/{returnId}/rmas` to `/returns/{returnId}/external-rmas`
- Updates operation ID, summaries, and descriptions to reflect "external RMA"
- Renames source file from `return-create-rma.path.yaml` to `return-create-external-rma.path.yaml`

## Test plan
- [x] OpenAPI validation passes (`mintlify openapi-check`)
- [ ] Verify downstream consumers are updated to use the new endpoint path

🤖 Generated with [Claude Code](https://claude.com/claude-code)