### PR TITLE
Add integration documentation across all categories

### DIFF
--- a/redo/docs.json
+++ b/redo/docs.json
@@ -123,28 +123,42 @@
                 "group": "Carts & Checkouts",
                 "root": "/docs/integrations/returns/carts-checkouts/overview",
                 "pages": [
-                  "/docs/integrations/returns/carts-checkouts/overview"
+                  "/docs/integrations/returns/carts-checkouts/overview",
+                  "/docs/integrations/returns/carts-checkouts/bolt",
+                  "/docs/integrations/returns/carts-checkouts/tapcart",
+                  "/docs/integrations/returns/carts-checkouts/vajro"
                 ]
               },
               {
                 "group": "Marketing & Loyalty",
                 "root": "/docs/integrations/returns/marketing-loyalty/overview",
                 "pages": [
-                  "/docs/integrations/returns/marketing-loyalty/overview"
+                  "/docs/integrations/returns/marketing-loyalty/overview",
+                  "/docs/integrations/returns/marketing-loyalty/klaviyo",
+                  "/docs/integrations/returns/marketing-loyalty/recharge",
+                  "/docs/integrations/returns/marketing-loyalty/rise-ai",
+                  "/docs/integrations/returns/marketing-loyalty/rivo"
                 ]
               },
               {
                 "group": "Returns Services",
                 "root": "/docs/integrations/returns/returns-services/overview",
                 "pages": [
-                  "/docs/integrations/returns/returns-services/overview"
+                  "/docs/integrations/returns/returns-services/overview",
+                  "/docs/integrations/returns/returns-services/blueyonder",
+                  "/docs/integrations/returns/returns-services/inmar"
                 ]
               },
               {
                 "group": "Other Integrations",
                 "root": "/docs/integrations/returns/other/overview",
                 "pages": [
-                  "/docs/integrations/returns/other/overview"
+                  "/docs/integrations/returns/other/overview",
+                  "/docs/integrations/returns/other/gladly",
+                  "/docs/integrations/returns/other/global-e",
+                  "/docs/integrations/returns/other/gorgias",
+                  "/docs/integrations/returns/other/refundid",
+                  "/docs/integrations/returns/other/trynow"
                 ]
               }
             ]

--- a/redo/docs/integrations/returns/carts-checkouts/bolt.mdx
+++ b/redo/docs/integrations/returns/carts-checkouts/bolt.mdx
@@ -1,0 +1,71 @@
+---
+title: "Bolt"
+description: "Connect Bolt's one-click checkout experience with Redo"
+---
+
+import IntegrationSupport from '/snippets/integration-support.mdx';
+
+## What is Bolt?
+
+Bolt is a checkout experience platform that replaces a merchant's native
+checkout with an optimized, one-click checkout solution. Bolt's Universal Shopper
+Network recognizes returning customers across any Bolt-powered store, allowing
+them to complete purchases with a single click — no forms or passwords required.
+
+Key features include:
+
+- **One-click checkout** that reduces cart abandonment and increases conversion
+- **Universal Shopper Network** with access to millions of recognized shoppers
+- **Fraud detection** powered by machine learning to approve more legitimate
+  orders
+- **Platform support** for Shopify, BigCommerce, Adobe Commerce, and custom
+  storefronts
+
+## What Does the Integration Do?
+
+Redo integrates with Bolt to add a coverage toggle to the merchant's checkout
+page. When the toggle (or Redo's existing checkout integration) is present, Bolt
+auto-detects the Redo product and enables or disables it accordingly.
+
+The integration approach depends on your e-commerce platform.
+
+## How to Set It Up
+
+### Shopify
+
+Bolt is enabled on the backend by the Redo engineering team. Once enabled, a
+toggle is added to the merchant's checkout page.
+
+<Info>
+  If a Redo In Checkout (RIC) integration or the toggle already exists on the
+  checkout page, Bolt will automatically detect the Redo product.
+</Info>
+
+To get started, contact your Redo Customer Success Manager at
+**support@getredo.com**.
+
+### BigCommerce
+
+Setup is similar to Shopify. The integration supports regular and fee products
+via Redo In Checkout (RIC) and Checkout Buttons.
+
+<Warning>
+  Custom checkout fees are **not supported** on BigCommerce. BigCommerce custom
+  checkout fees can only be added within the checkout itself, and Redo cannot
+  inject widgets there.
+</Warning>
+
+To get started, contact your Redo Customer Success Manager at
+**support@getredo.com**.
+
+### Custom Integration
+
+For cases that don't fit the standard Shopify or BigCommerce setups — such as
+custom checkout fees — a fully custom integration is required. This involves
+working directly with Redo's engineering team and may require modifications to
+Redo's public API.
+
+Contact your Redo Customer Success Manager at **support@getredo.com** to discuss
+your requirements.
+
+<IntegrationSupport integrationProvider="Bolt" />

--- a/redo/docs/integrations/returns/carts-checkouts/overview.mdx
+++ b/redo/docs/integrations/returns/carts-checkouts/overview.mdx
@@ -8,4 +8,26 @@ Cart and checkout integrations allow Redo to connect with your custom shopping c
 
 ## Available Integrations
 
-Coming soon. Check back for updates on supported cart and checkout solutions.
+<CardGroup cols={2}>
+  <Card
+    title="Tapcart"
+    icon="mobile"
+    href="/docs/integrations/returns/carts-checkouts/tapcart"
+  >
+    Turn your Shopify store into a mobile app with Redo at checkout
+  </Card>
+  <Card
+    title="Vajro"
+    icon="mobile-screen-button"
+    href="/docs/integrations/returns/carts-checkouts/vajro"
+  >
+    No-code mobile app builder with Redo at Shopify checkout
+  </Card>
+  <Card
+    title="Bolt"
+    icon="bolt"
+    href="/docs/integrations/returns/carts-checkouts/bolt"
+  >
+    One-click checkout platform with Redo integration
+  </Card>
+</CardGroup>

--- a/redo/docs/integrations/returns/carts-checkouts/tapcart.mdx
+++ b/redo/docs/integrations/returns/carts-checkouts/tapcart.mdx
@@ -1,0 +1,62 @@
+---
+title: "Tapcart"
+description: "Enable Redo purchases within the Tapcart mobile app"
+---
+
+import IntegrationSupport from '/snippets/integration-support.mdx';
+
+## What is Tapcart?
+
+Tapcart is a mobile app builder for Shopify that turns your online store into a
+native iOS and Android app. It features a drag-and-drop editor, real-time
+syncing with your Shopify catalog, unlimited push notifications, and AI-powered
+personalization — all without requiring any code.
+
+## What Does the Integration Do?
+
+The Redo integration allows customers to purchase Redo directly within the
+Tapcart mobile app. Depending on your checkout setup, Redo can appear either
+through the Shopify Plus checkout or through Tapcart's native checkout
+experience.
+
+## How to Set It Up
+
+Tapcart supports two checkout options depending on your Shopify plan. Choose the
+one that applies to your store.
+
+### Shopify Plus Checkout
+
+If you have Shopify Plus, you can use the Shopify checkout experience within
+Tapcart.
+
+<Steps>
+<Step title="Update Attachment Strategy">
+  Change the merchant's attachment strategy to **Checkout** in the Redo Admin
+  dashboard.
+</Step>
+
+<Step title="Add Tapcart as a Sales Channel">
+  Go to Shopify, find the **Redo product**, and add **Tapcart** as a sales
+  channel.
+</Step>
+</Steps>
+
+### Tapcart Checkout
+
+If you use Tapcart's native checkout, setup requires an **enterprise account on
+Tapcart**.
+
+<Steps>
+<Step title="Add Redo to Cart or PDP Pages">
+  In the Tapcart dashboard, navigate to the editor for your **Cart** or **PDP
+  pages** and add the Redo widget.
+</Step>
+</Steps>
+
+<Info>
+  In-depth setup instructions for the Tapcart checkout option are only available
+  for merchants with **Shopify Plus** and an **enterprise Tapcart account**.
+  Contact your Tapcart account manager for detailed guidance.
+</Info>
+
+<IntegrationSupport integrationProvider="Tapcart" />

--- a/redo/docs/integrations/returns/carts-checkouts/vajro.mdx
+++ b/redo/docs/integrations/returns/carts-checkouts/vajro.mdx
@@ -1,0 +1,56 @@
+---
+title: "Vajro"
+description: "Enable Redo at checkout in the Vajro mobile app"
+---
+
+import IntegrationSupport from '/snippets/integration-support.mdx';
+
+## What is Vajro?
+
+Vajro is a no-code mobile app builder for Shopify stores that allows businesses
+to create native Android and iOS apps without coding. It features a
+drag-and-drop interface for customization and automatically syncs with your
+Shopify store to keep products, inventory, and customer data up to date. Key
+features include push notifications, live video selling, app-only discounts,
+multilingual support, and in-app analytics.
+
+## What Does the Integration Do?
+
+Redo does not have a direct integration with Vajro. However, if the merchant uses
+**Shopify Plus** and **Shopify Checkout** as the checkout experience within
+Vajro, Redo can appear as a widget at checkout in the Vajro mobile app.
+
+## How to Set It Up
+
+### Prerequisites
+
+<AccordionGroup>
+<Accordion title="Shopify Plus" icon="circle-check">
+  The merchant must be on a **Shopify Plus** plan. This integration is not
+  available on standard Shopify plans.
+</Accordion>
+
+<Accordion title="Shopify Checkout in Vajro" icon="cart-shopping">
+  Vajro must be configured to use **Shopify Checkout** as the checkout
+  experience (rather than Vajro's built-in checkout).
+</Accordion>
+</AccordionGroup>
+
+### Configuration Steps
+
+<Steps>
+<Step title="Update Attachment Strategy">
+  Change the merchant's attachment strategy to **Checkout** in the Redo Admin
+  dashboard.
+</Step>
+
+<Step title="Add Vajro as a Sales Channel">
+  Go to Shopify, find the **Redo product**, and add **Vajro** as a sales channel.
+</Step>
+</Steps>
+
+## How Long Does It Take?
+
+Setup takes approximately **2 minutes** once both prerequisites are met.
+
+<IntegrationSupport integrationProvider="Vajro" />

--- a/redo/docs/integrations/returns/marketing-loyalty/klaviyo.mdx
+++ b/redo/docs/integrations/returns/marketing-loyalty/klaviyo.mdx
@@ -1,0 +1,141 @@
+---
+title: "Klaviyo"
+description: "Use Redo return and order tracking events in Klaviyo marketing flows"
+---
+
+import IntegrationSupport from '/snippets/integration-support.mdx';
+
+## What is Klaviyo?
+
+Klaviyo is a marketing automation platform that helps merchants engage customers
+through email and SMS campaigns. The Redo integration sends return and order
+tracking events to Klaviyo, allowing merchants to use them in automated flows —
+for example, sending a personalized email when a customer creates a return.
+
+## What Does the Integration Do?
+
+Redo sends the following events to Klaviyo. Each event can be used as a trigger
+in Klaviyo flows.
+
+### Return Created
+
+Triggered when a customer submits a return.
+
+- **Metric:** Total return value
+
+| Property    | Description                         |
+| ----------- | ----------------------------------- |
+| ReturnId    | Return ID                           |
+| OrderRef    | Shopify order name                  |
+| NewOrderRef | Shopify new order name              |
+| Coverage    | `covered` or `not covered`          |
+| Delivery    | `label`, `pickup`, or `none` (green return) |
+| Quantity    | Total quantity of items returned     |
+
+### Return Created Item
+
+Triggered for each individual item in a return.
+
+- **Metric:** Return value
+
+| Property       | Description                           |
+| -------------- | ------------------------------------- |
+| ReturnId       | Return ID                             |
+| Type           | `refund`, `store_credit`, or `exchange` |
+| OrderRef       | Shopify order name                    |
+| NewOrderRef    | Shopify new order name (if exists)    |
+| Coverage       | `covered` or `not covered`            |
+| SKU            | Item SKU                              |
+| NewSKU         | Exchange item SKU (if exists)         |
+| ProductName    | Original product name                 |
+| NewProductName | Exchange product name (if exists)     |
+| VariantName    | Original variant name                 |
+| NewVariantName | Exchange variant name (if exists)     |
+| Quantity       | Item quantity                         |
+
+### Order Tracking Update
+
+Triggered on order tracking status changes. Only available if order tracking is
+enabled.
+
+| Property              | Description                                  |
+| --------------------- | -------------------------------------------- |
+| Trigger               | Tracking status (see values below)           |
+| OrderRef              | Shopify order name                           |
+| Date                  | Date of the tracking event                   |
+| TrackingPageLink      | Link to Redo's tracking page in the customer portal |
+| OrderCreatedDate      | Date the order was created                   |
+| OrderShippedDate      | Date the order was shipped (if shipped)      |
+| OrderDeliveredDate    | Date the order was delivered (if delivered)  |
+| EstimatedDeliveryDate | Estimated delivery date                      |
+
+### Order Tracking Update Item
+
+Triggered for each item in a tracking update. Only available if order tracking is
+enabled.
+
+| Property    | Description                        |
+| ----------- | ---------------------------------- |
+| Trigger     | Tracking status (see values below) |
+| OrderRef    | Shopify order name                 |
+| SKU         | Item SKU                           |
+| ProductName | Product name                       |
+| VariantName | Variant name                       |
+| Quantity    | Item quantity                      |
+
+### Tracking Status Values
+
+The `Trigger` property for order tracking events can be one of the following:
+
+`order_created`, `pre_transit`, `in_transit`, `out_for_delivery`, `delivered`,
+`available_for_pickup`, `stalled_in_transit`, `delayed`, `arriving_early`,
+`return_to_sender`, `delivery_attempted`, `failure`, `cancelled`, `error`
+
+### Other Events
+
+- **Customer Account Created** — triggered when a customer account is created
+- **Product Added to Wishlist** — triggered when a customer adds a product to
+  their wishlist from the order tracking page
+
+### Marketing Consent Syncing
+
+- If a customer signs up for SMS updates on the order tracking page and checks
+  the marketing consent box, the new subscriber is synced with Klaviyo.
+- If Redo's marketing product is enabled, email/SMS marketing sign-ups also
+  create the customer and subscription in Klaviyo.
+
+## How to Set It Up
+
+<Steps>
+<Step title="Generate a Klaviyo API Key">
+  Sign in to Klaviyo and go to **Settings** > **API Keys**. Click **Create
+  Private API Key**.
+
+  Enter a name for the key, then choose either **Full Access Token** or
+  **Custom Key**. If you choose Custom Key, grant **Full Access** to the
+  following API scopes:
+  - **Events** (required)
+  - **Profiles** (required for order tracking integration)
+</Step>
+
+<Step title="Copy the API Key">
+  After clicking **Create**, copy the generated API key from the success screen.
+
+  <Warning>
+    This is the only time you can view and copy the key. Store it securely.
+  </Warning>
+</Step>
+
+<Step title="Send the API Key to Redo">
+  Send the API key to **support@getredo.com**. The Redo team will configure the
+  integration on our end.
+</Step>
+</Steps>
+
+## How Long Does It Take?
+
+Setup takes approximately **10 minutes** for the merchant to generate and send
+the API key. The Redo team will complete the configuration shortly after
+receiving it.
+
+<IntegrationSupport integrationProvider="Klaviyo" />

--- a/redo/docs/integrations/returns/marketing-loyalty/overview.mdx
+++ b/redo/docs/integrations/returns/marketing-loyalty/overview.mdx
@@ -8,4 +8,33 @@ Marketing and loyalty integrations connect Redo with your customer engagement pl
 
 ## Available Integrations
 
-Coming soon. Check back for updates on supported marketing and loyalty platforms.
+<CardGroup cols={2}>
+  <Card
+    title="Klaviyo"
+    icon="envelope"
+    href="/docs/integrations/returns/marketing-loyalty/klaviyo"
+  >
+    Use Redo return and order tracking events in email and SMS flows
+  </Card>
+  <Card
+    title="Recharge"
+    icon="arrows-rotate"
+    href="/docs/integrations/returns/marketing-loyalty/recharge"
+  >
+    Include Redo in subscription selling plans
+  </Card>
+  <Card
+    title="Rise.ai"
+    icon="coins"
+    href="/docs/integrations/returns/marketing-loyalty/rise-ai"
+  >
+    Issue return store credit as Rise.ai rewards
+  </Card>
+  <Card
+    title="Rivo"
+    icon="star"
+    href="/docs/integrations/returns/marketing-loyalty/rivo"
+  >
+    Display loyalty points balance within Redo returns
+  </Card>
+</CardGroup>

--- a/redo/docs/integrations/returns/marketing-loyalty/recharge.mdx
+++ b/redo/docs/integrations/returns/marketing-loyalty/recharge.mdx
@@ -1,0 +1,52 @@
+---
+title: "Recharge"
+description: "Include Redo in Recharge subscription selling plans"
+---
+
+import IntegrationSupport from '/snippets/integration-support.mdx';
+
+## What is Recharge?
+
+Recharge is a Shopify app that enables merchants to offer selling plans on their
+products. Selling plans can include subscriptions for customers to receive
+products on a recurring basis. The integration allows Redo to be included in
+those subscriptions so customers stay covered.
+
+## What Does the Integration Do?
+
+When a merchant uses Recharge for subscriptions, the Redo product needs to be
+configured within Recharge so that it can be purchased alongside both one-time
+and subscription orders.
+
+## How to Set It Up
+
+<Steps>
+<Step title="Open the Redo Product in Recharge">
+  In the Recharge app, navigate to the **Redo product** page.
+</Step>
+
+<Step title="Enable One-Time Purchasing">
+  Ensure the Redo product is available as a **one-time product** so it can still
+  be purchased with non-subscription orders.
+</Step>
+
+<Step title="Create Matching Subscription Plans">
+  Create a subscription selling plan on the Redo product for **each subscription
+  interval** you offer on your other products.
+
+  For example, if you offer 2-week, 30-day, and 60-day subscriptions on your
+  products, create a corresponding plan for each of those intervals on the Redo
+  product.
+
+  <Warning>
+    Do **not** add a discount for subscribing to Redo. The subscription plan
+    should match the interval only.
+  </Warning>
+</Step>
+</Steps>
+
+## How Long Does It Take?
+
+Setup takes approximately **10 minutes**.
+
+<IntegrationSupport integrationProvider="Recharge" />

--- a/redo/docs/integrations/returns/marketing-loyalty/rise-ai.mdx
+++ b/redo/docs/integrations/returns/marketing-loyalty/rise-ai.mdx
@@ -1,0 +1,97 @@
+---
+title: "Rise.ai"
+description: "Issue return store credit as Rise.ai rewards instead of Shopify store credit"
+---
+
+import IntegrationSupport from '/snippets/integration-support.mdx';
+
+## What is Rise.ai?
+
+Rise.ai is a store credit and rewards platform for e-commerce merchants. It
+manages gift cards, loyalty rewards, and store credit balances for customers.
+
+## What Does the Integration Do?
+
+When Redo issues store credit for a return, it is issued as a reward to the
+customer's Rise.ai account instead of as standard Shopify store credit. This
+keeps all store credit and rewards consolidated within Rise.ai.
+
+## How to Set It Up
+
+### Prerequisites
+
+<AccordionGroup>
+<Accordion title="Rise.ai Enterprise Plan" icon="circle-check">
+  This integration is only available for merchants on a **Rise.ai Enterprise**
+  plan.
+</Accordion>
+</AccordionGroup>
+
+### Step A: Create a Workflow in Rise.ai
+
+The merchant must complete the following steps in their Rise.ai dashboard.
+
+<Steps>
+<Step title="Navigate to Loyalty & Rewards">
+  In Rise.ai, click **Loyalty & Rewards**.
+</Step>
+
+<Step title="Create a New Workflow">
+  Click **Create Workflow**, scroll down, and click **Create your own**.
+</Step>
+
+<Step title="Create a Custom Trigger">
+  On the left side, under **Custom Triggers**, click **Create your own** and
+  enter the following:
+
+  - **Name:** `Redo Return`
+  - **Description:** `Return for store credit created in Redo`
+</Step>
+
+<Step title="Configure Variables">
+  Add the following variables to the trigger:
+
+  | Variable Name  | Type   | Key              |
+  | -------------- | ------ | ---------------- |
+  | Customer Email | Email  | `customer_email` |
+  | Return Credit  | Number | `return_credit`  |
+
+  Click **Create Trigger** when finished.
+</Step>
+
+<Step title="Copy the Trigger URL">
+  On the left side, under **Custom Triggers**, click **Settings** for the
+  trigger you just created. Scroll to the bottom and **copy the URL**.
+
+  The URL will look similar to:
+  ```
+  https://workflows.rise-ai.com/execute/272d2fa4-667d-4867-834a-bb1bb0300901
+  ```
+
+  Save this URL — you will send it to Redo in the final step.
+</Step>
+
+<Step title="Configure the Action">
+  On the left side, under **Custom Triggers**, click the trigger you created.
+  Click **Add action** and select **Issue Store Credit**.
+
+  Enter the following:
+  - **Percentage:** `100%` of **Return Credit**
+</Step>
+
+<Step title="Enable and Save">
+  In the upper right, **enable** the workflow and click **Save**.
+</Step>
+
+<Step title="Send the Trigger URL to Redo">
+  Send the trigger URL you copied in Step 5 to **support@getredo.com**. The
+  Redo team will finalize the integration on our end.
+</Step>
+</Steps>
+
+## How Long Does It Take?
+
+Setup takes up to **2 business days** after the merchant completes the steps
+above and sends the trigger URL to Redo.
+
+<IntegrationSupport integrationProvider="Rise.ai" />

--- a/redo/docs/integrations/returns/marketing-loyalty/rivo.mdx
+++ b/redo/docs/integrations/returns/marketing-loyalty/rivo.mdx
@@ -1,0 +1,44 @@
+---
+title: "Rivo"
+description: "Display Rivo loyalty points balance within Redo returns"
+---
+
+import IntegrationSupport from '/snippets/integration-support.mdx';
+
+## What is Rivo?
+
+Rivo is a loyalty and referral platform for Shopify merchants. It allows
+businesses to create reward systems where customers earn points for actions like
+purchases or reviews, which can be redeemed for discounts or other perks. Rivo
+also offers a membership platform for creating paid subscription programs with
+recurring revenue and exclusive benefits.
+
+## What Does the Integration Do?
+
+The integration displays the customer's Rivo loyalty points balance on the return
+page within the customer information section. This gives your team visibility
+into a customer's loyalty status when processing returns.
+
+## How to Set It Up
+
+<Steps>
+<Step title="Get Your Rivo API Key">
+  In the Rivo app, go to **Settings** > **Developer Toolkit** and copy your API
+  key.
+
+  See [Rivo's documentation](https://help.rivo.io/en/articles/8544831-how-to-get-your-rivo-api-key)
+  for detailed instructions on accessing your API key.
+</Step>
+
+<Step title="Connect Rivo in the Redo Dashboard">
+  In the Redo merchant dashboard, go to **Returns & Claims** > **Integrations**
+  and click the **Connect** button under the Rivo integration. Enter your API key
+  when prompted.
+</Step>
+</Steps>
+
+## How Long Does It Take?
+
+Setup takes less than **5 minutes**.
+
+<IntegrationSupport integrationProvider="Rivo" />

--- a/redo/docs/integrations/returns/other/gladly.mdx
+++ b/redo/docs/integrations/returns/other/gladly.mdx
@@ -1,0 +1,25 @@
+---
+title: "Gladly"
+description: "View Redo return data within the Gladly customer service platform"
+---
+
+import IntegrationSupport from '/snippets/integration-support.mdx';
+
+## What is Gladly?
+
+Gladly is a customer service platform built for e-commerce brands. It provides a
+unified view of each customer across all communication channels — email, chat,
+phone, SMS, and social — organized around the customer rather than individual
+tickets.
+
+## What Does the Integration Do?
+
+The Redo integration surfaces return data within Gladly so support agents have
+visibility into a customer's return history while handling conversations.
+
+## How to Set It Up
+
+For setup instructions, contact your Redo Customer Success Manager at
+**support@getredo.com**.
+
+<IntegrationSupport integrationProvider="Gladly" />

--- a/redo/docs/integrations/returns/other/global-e.mdx
+++ b/redo/docs/integrations/returns/other/global-e.mdx
@@ -1,0 +1,46 @@
+---
+title: "Global-e"
+description: "Manage cross-border returns with Global-e for international shipping and duty recovery"
+---
+
+import IntegrationSupport from '/snippets/integration-support.mdx';
+
+## What is Global-e?
+
+Global-e is a cross-border e-commerce platform that manages international
+shipping, taxes, duties, and currency conversion. It enables merchants to sell
+and ship internationally while handling the complexity of localized pricing,
+compliance, and logistics.
+
+## What Does the Integration Do?
+
+The Redo and Global-e integration handles several aspects of international
+returns:
+
+- **Return labels** — Redo uses Global-e's return labels (via DHL) so merchants
+  can participate in duty drawback programs to recoup duties and fees. Global-e
+  only offers this benefit when their return labels are used.
+- **Country-based return fees** — Global-e charges different return fees based on
+  the customer's country, presented in the shopper's local currency.
+- **Direct refunds** — Since payments for Global-e orders are not housed in
+  Shopify, Redo refunds directly through Global-e rather than through Shopify.
+
+<Warning>
+  Exchanges are not recommended for international orders processed through
+  Global-e. If exchanges are offered, the merchant assumes full responsibility
+  for duties and fees and loses the cost recouping benefits of processing returns
+  through Global-e.
+</Warning>
+
+<Info>
+  An order must have a status of **Dispatched** (equivalent to "fulfilled") in
+  Global-e before it can be returned.
+</Info>
+
+## How to Set It Up
+
+For setup instructions, contact your Redo Customer Success Manager at
+**support@getredo.com**. The team will work with you and Global-e to configure
+return labels, refund routing, and return fee settings.
+
+<IntegrationSupport integrationProvider="Global-e" />

--- a/redo/docs/integrations/returns/other/gorgias.mdx
+++ b/redo/docs/integrations/returns/other/gorgias.mdx
@@ -1,0 +1,55 @@
+---
+title: "Gorgias"
+description: "View Redo return data directly within Gorgias support tickets"
+---
+
+import IntegrationSupport from '/snippets/integration-support.mdx';
+
+## What is Gorgias?
+
+Gorgias is a customer support helpdesk built for e-commerce. The Redo
+integration adds a sidebar widget to Gorgias that displays return information
+for the customer associated with a support ticket, with direct links back to
+Redo for quick processing.
+
+## What Does the Integration Do?
+
+When a support ticket is created or updated in Gorgias, Redo automatically loads
+the customer's return history from the previous 2 months. The return data is
+displayed alongside the ticket with hyperlinks that take the agent directly to
+the relevant order in Redo.
+
+## How to Set It Up
+
+Merchants can set up this integration themselves from Gorgias.
+
+<Steps>
+<Step title="Find Redo in the Gorgias App Store">
+  In Gorgias, find **Redo** in the app store and click **Connect**. You'll be
+  taken to a login screen on Redo's site.
+</Step>
+
+<Step title="Log In to Redo">
+  Select your store and log in. You'll be directed to a Redo x Gorgias
+  connection page.
+</Step>
+
+<Step title="Authorize the Connection">
+  Click **Continue**. This redirects you back to Gorgias to finalize the
+  authorization.
+</Step>
+
+<Step title="Complete Setup">
+  After authorizing, you'll be redirected to Redo. Redo will automatically set
+  up the integration in your Gorgias store.
+</Step>
+</Steps>
+
+Once connected, return data will automatically load into your tickets whenever a
+ticket is created or updated.
+
+## How Long Does It Take?
+
+Setup takes approximately **5 minutes**.
+
+<IntegrationSupport integrationProvider="Gorgias" />

--- a/redo/docs/integrations/returns/other/overview.mdx
+++ b/redo/docs/integrations/returns/other/overview.mdx
@@ -8,4 +8,40 @@ Other integrations include a variety of tools and services that complement Redo'
 
 ## Available Integrations
 
-Coming soon. Check back for updates on additional integration options.
+<CardGroup cols={2}>
+  <Card
+    title="Gladly"
+    icon="headset"
+    href="/docs/integrations/returns/other/gladly"
+  >
+    View return data within the Gladly customer service platform
+  </Card>
+  <Card
+    title="Global-e"
+    icon="globe"
+    href="/docs/integrations/returns/other/global-e"
+  >
+    Cross-border returns with international shipping and duty recovery
+  </Card>
+  <Card
+    title="Gorgias"
+    icon="message-dots"
+    href="/docs/integrations/returns/other/gorgias"
+  >
+    View return data directly within Gorgias support tickets
+  </Card>
+  <Card
+    title="Refundid"
+    icon="money-bill-transfer"
+    href="/docs/integrations/returns/other/refundid"
+  >
+    Prevent duplicate returns across Redo and Refundid
+  </Card>
+  <Card
+    title="TryNow"
+    icon="bag-shopping"
+    href="/docs/integrations/returns/other/trynow"
+  >
+    Handle returns for try-before-you-buy orders
+  </Card>
+</CardGroup>

--- a/redo/docs/integrations/returns/other/refundid.mdx
+++ b/redo/docs/integrations/returns/other/refundid.mdx
@@ -1,0 +1,32 @@
+---
+title: "Refundid"
+description: "Prevent duplicate returns between Redo and Refundid"
+---
+
+import IntegrationSupport from '/snippets/integration-support.mdx';
+
+## What is Refundid?
+
+Refundid is a returns service that provides customers with instant refunds or
+exchanges — customers receive their funds before shipping items back. Shoppers
+create a Refundid account, initiate a return through their dashboard, and receive
+their refund within seconds.
+
+## What Does the Integration Do?
+
+The integration prevents duplicate returns across Redo and Refundid:
+
+- If an item has already been returned through Refundid, Redo will not allow it
+  to be returned again in the Redo portal.
+- During processing, Redo checks whether the item was returned in Refundid and
+  skips processing if so.
+
+This protects against scenarios where a return is processed in Redo first and the
+customer then submits the same return in Refundid (or vice versa).
+
+## How to Set It Up
+
+For setup instructions, contact your Redo Customer Success Manager at
+**support@getredo.com**.
+
+<IntegrationSupport integrationProvider="Refundid" />

--- a/redo/docs/integrations/returns/other/trynow.mdx
+++ b/redo/docs/integrations/returns/other/trynow.mdx
@@ -1,0 +1,28 @@
+---
+title: "TryNow"
+description: "Handle returns for try-before-you-buy orders without issuing refunds"
+---
+
+import IntegrationSupport from '/snippets/integration-support.mdx';
+
+## What is TryNow?
+
+TryNow is a try-before-you-buy platform for Shopify. It allows customers to
+order products without being charged upfront — they try items at home and are
+only charged for what they keep after a trial period.
+
+## What Does the Integration Do?
+
+Redo detects when an item was purchased through TryNow and the customer hasn't
+been charged for it yet. In that case, Redo skips issuing a refund and instead
+notifies TryNow not to charge the customer for the returned item.
+
+This prevents double credits — if the customer was never charged, there's nothing
+to refund.
+
+## How to Set It Up
+
+For setup instructions, contact your Redo Customer Success Manager at
+**support@getredo.com**.
+
+<IntegrationSupport integrationProvider="TryNow" />

--- a/redo/docs/integrations/returns/returns-services/blueyonder.mdx
+++ b/redo/docs/integrations/returns/returns-services/blueyonder.mdx
@@ -1,0 +1,38 @@
+---
+title: "BlueYonder"
+description: "Offer boxless return drop-offs through BlueYonder locations"
+---
+
+import IntegrationSupport from '/snippets/integration-support.mdx';
+
+## What is BlueYonder?
+
+BlueYonder is a returns service that provides **boxless returns** — customers can
+drop off their return items at a nearby BlueYonder location without needing to
+package them. This offers a more convenient return experience at a lower cost
+than traditional shipping.
+
+<Info>
+  BlueYonder is not the same as **Inmar**, which provides return dispositioning
+  and inspection services. These are separate integrations.
+</Info>
+
+## What Does the Integration Do?
+
+When a customer initiates a return with a merchant that has BlueYonder enabled,
+Redo can show a list of nearby BlueYonder drop-off locations. If the customer
+chooses a BlueYonder location:
+
+1. A label fee is still charged to the customer.
+2. Redo creates a return in BlueYonder, which generates a **QR code**.
+3. The customer takes the QR code to the drop-off location — no packaging
+   required.
+4. Redo receives webhook notifications from BlueYonder to track when the
+   customer has delivered their items.
+
+## How to Set It Up
+
+For setup instructions, contact your Redo Customer Success Manager at
+**support@getredo.com**.
+
+<IntegrationSupport integrationProvider="BlueYonder" />

--- a/redo/docs/integrations/returns/returns-services/inmar.mdx
+++ b/redo/docs/integrations/returns/returns-services/inmar.mdx
@@ -1,0 +1,105 @@
+---
+title: "Inmar"
+description: "Automated return dispositioning through Inmar reverse logistics"
+---
+
+import IntegrationSupport from '/snippets/integration-support.mdx';
+
+## What is Inmar?
+
+Inmar is a reverse logistics provider (an acquisition of DHL) that handles
+return dispositioning — the process of inspecting, sorting, and routing returned
+items based on their condition. Inmar operates a network of reverse logistics
+warehouses across the country.
+
+<Info>
+  Inmar is not the same as **BlueYonder**, which provides boxless return drop-off
+  services. These are separate integrations.
+</Info>
+
+## What Does the Integration Do?
+
+When a customer submits a return through Redo, an RMA is automatically created
+in Inmar's system. Inmar then inspects the returned items at their warehouse and
+sends dispositioning updates back to Redo (e.g., return to sender, ship back to
+warehouse). These updates allow Redo to automatically process the return based
+on Inmar's inspection results.
+
+## How to Set It Up
+
+### Prerequisites
+
+Before integrating with Redo, the merchant must complete several steps with
+Inmar directly.
+
+<AccordionGroup>
+<Accordion title="Active Inmar Account" icon="circle-check">
+  The merchant must already be connected with Inmar. This includes:
+
+  - **Defining business rules** with Inmar for dispositioning (e.g., return to
+    sender when applicable, ship back to warehouse when in good condition)
+  - **Sharing master data** with Inmar — a table of product information including
+    UPC, SKU, weight, price, and other details for each item
+  - **Selecting warehouses** — deciding which of Inmar's reverse logistics
+    warehouses the merchant will use
+</Accordion>
+
+<Accordion title="Inmar Credentials" icon="key">
+  Inmar will provision the following merchant-specific credentials:
+
+  - **Merchant consumer ID**
+  - **Merchant webhook secret**
+  - **Warehouse list** — which Inmar warehouses the merchant uses
+</Accordion>
+
+<Accordion title="Product SKU/UPC Data" icon="barcode">
+  The merchant must have per-product and per-variant **SKU and UPC** for all
+  products and orders. The physical products must also have these codes present
+  on the items, as the dispositioning team scans them to verify return contents
+  match the customer's submission.
+
+  <Info>
+    Inmar is transitioning away from requiring UPCs. In the future, only SKU
+    will be required.
+  </Info>
+</Accordion>
+
+<Accordion title="Compatible Shipping Methods" icon="truck">
+  Merchants must use return shipment methods that provide a label with a unique,
+  scannable barcode (e.g., FedEx, USPS, or any carrier that provides a tracking
+  number barcode on the label).
+
+  <Warning>
+    In-store returns are **not compatible** with Inmar, since they don't generate
+    shipping labels with scannable barcodes.
+  </Warning>
+</Accordion>
+</AccordionGroup>
+
+### Configuration Steps
+
+<Steps>
+<Step title="Navigate to Integrations">
+  In the Redo merchant dashboard, go to **Return Settings** > **Integrations**.
+</Step>
+
+<Step title="Add the Inmar Integration">
+  Click to add the **Inmar** integration.
+</Step>
+
+<Step title="Enter Credentials">
+  Enter the merchant consumer ID and webhook secret provided by Inmar.
+</Step>
+
+<Step title="Configure Shipping Addresses">
+  Set up shipping addresses by tagging existing shipping location data with the
+  corresponding **Inmar location ID** for each warehouse.
+</Step>
+
+<Step title="Configure Return Automation">
+  Set up return automation settings for processing events so that returns are
+  automatically processed based on Inmar's dispositioning updates.
+</Step>
+</Steps>
+
+<IntegrationSupport integrationProvider="Inmar" />

--- a/redo/docs/integrations/returns/returns-services/overview.mdx
+++ b/redo/docs/integrations/returns/returns-services/overview.mdx
@@ -8,4 +8,19 @@ Returns service integrations connect Redo with specialized return handling provi
 
 ## Available Integrations
 
-Coming soon. Check back for updates on supported returns service providers.
+<CardGroup cols={2}>
+  <Card
+    title="BlueYonder"
+    icon="box-open"
+    href="/docs/integrations/returns/returns-services/blueyonder"
+  >
+    Boxless return drop-offs at nearby locations
+  </Card>
+  <Card
+    title="Inmar"
+    icon="warehouse"
+    href="/docs/integrations/returns/returns-services/inmar"
+  >
+    Automated return dispositioning through reverse logistics warehouses
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

- **Carts & Checkouts**: Added Bolt (Shopify, BigCommerce, custom), Tapcart (Shopify Plus + Tapcart checkout paths), and Vajro (Shopify Plus only) integration docs
- **Marketing & Loyalty**: Added Klaviyo (full event reference with return/tracking events and properties), Recharge (subscription selling plans), Rise.ai (store credit rewards with workflow setup), and Rivo (loyalty points via API key) integration docs
- **Returns Services**: Added Inmar (reverse logistics dispositioning with detailed prerequisites) and BlueYonder (boxless return drop-offs) integration docs
- **Other Integrations**: Added Gorgias (self-serve sidebar widget setup), Global-e (cross-border returns with duty recovery), Gladly (customer service platform), Refundid (duplicate return prevention), and TryNow (try-before-you-buy handling) integration docs
- Updated all overview pages with CardGroup tiles and docs.json navigation for all 14 new integration pages

## Test plan

- [ ] Run `bazel run docs` and verify all new pages render correctly
- [ ] Check that all overview CardGroup tiles link to the correct pages
- [ ] Verify docs.json navigation shows all new pages in the sidebar
- [ ] Confirm the IntegrationSupport snippet renders properly on each page
- [ ] Run `bazel run docs -- broken-links` to check for broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)