### PR TITLE
Add Purple Dot and CreditsYard integration docs

### DIFF
--- a/redo/docs.json
+++ b/redo/docs.json
@@ -105,6 +105,22 @@
                   "/docs/integrations/returns/3pl-wms/shipstream",
                   "/docs/integrations/returns/3pl-wms/rydership"
                 ]
+              },
+              {
+                "group": "Marketing & Loyalty",
+                "root": "/docs/integrations/returns/marketing-loyalty/overview",
+                "pages": [
+                  "/docs/integrations/returns/marketing-loyalty/overview",
+                  "/docs/integrations/returns/marketing-loyalty/creditsyard"
+                ]
+              },
+              {
+                "group": "Other Integrations",
+                "root": "/docs/integrations/returns/other/overview",
+                "pages": [
+                  "/docs/integrations/returns/other/overview",
+                  "/docs/integrations/returns/other/purple-dot"
+                ]
               }
             ]
           }

--- a/redo/docs/integrations/returns/marketing-loyalty/creditsyard.mdx
+++ b/redo/docs/integrations/returns/marketing-loyalty/creditsyard.mdx
@@ -1,0 +1,26 @@
+---
+title: "CreditsYard"
+description: "Issue return store credit as CreditsYard rewards instead of Shopify store credit"
+---
+
+import IntegrationSupport from '/snippets/integration-support.mdx';
+
+## What is CreditsYard?
+
+CreditsYard is a store credit management platform for Shopify that provides a
+digital wallet for returns, exchanges, and cashback rewards. It helps merchants
+turn returns into repurchases by keeping the value in-store, with support for
+online, POS, and B2B redemption.
+
+## What Does the Integration Do?
+
+When Redo issues store credit for a return, it is issued as a reward to the
+customer's CreditsYard account instead of as standard Shopify store credit. This
+keeps all store credit and rewards consolidated within CreditsYard.
+
+## How to Set It Up
+
+For setup instructions, contact your Redo Customer Success Manager at
+**support@getredo.com**.
+
+<IntegrationSupport integrationProvider="CreditsYard" />

--- a/redo/docs/integrations/returns/marketing-loyalty/overview.mdx
+++ b/redo/docs/integrations/returns/marketing-loyalty/overview.mdx
@@ -1,0 +1,19 @@
+---
+title: "Overview"
+description: "Connect marketing and loyalty platforms to enhance your return experience"
+icon: "book-open"
+---
+
+Marketing and loyalty integrations connect Redo with your customer engagement platforms. These integrations enable you to leverage return data in your marketing campaigns, reward loyal customers through the return process, and create personalized experiences that turn returns into opportunities for customer retention and growth.
+
+## Available Integrations
+
+<CardGroup cols={2}>
+  <Card
+    title="CreditsYard"
+    icon="wallet"
+    href="/docs/integrations/returns/marketing-loyalty/creditsyard"
+  >
+    Issue return store credit as CreditsYard rewards
+  </Card>
+</CardGroup>

--- a/redo/docs/integrations/returns/other/overview.mdx
+++ b/redo/docs/integrations/returns/other/overview.mdx
@@ -1,0 +1,19 @@
+---
+title: "Overview"
+description: "Additional integrations to extend Redo's capabilities"
+icon: "book-open"
+---
+
+Other integrations include a variety of tools and services that complement Redo's return management capabilities. These integrations help you connect Redo with your broader business ecosystem, from accounting systems to customer service platforms, ensuring a fully integrated return management solution.
+
+## Available Integrations
+
+<CardGroup cols={2}>
+  <Card
+    title="Purple Dot"
+    icon="circle-dot"
+    href="/docs/integrations/returns/other/purple-dot"
+  >
+    Prevent preorder products from being selected as exchanges
+  </Card>
+</CardGroup>

--- a/redo/docs/integrations/returns/other/purple-dot.mdx
+++ b/redo/docs/integrations/returns/other/purple-dot.mdx
@@ -1,0 +1,25 @@
+---
+title: "Purple Dot"
+description: "Prevent preorder products from being selected as exchange items"
+---
+
+import IntegrationSupport from '/snippets/integration-support.mdx';
+
+## What is Purple Dot?
+
+Purple Dot is a pre-order management platform for Shopify that lets merchants
+sell products before they have stock. Customers check out for free, their card
+is vaulted, and they are auto-charged when the merchant is ready to ship.
+
+## What Does the Integration Do?
+
+The integration prevents preorder products from being selected as exchange items
+during the return process. Since preorder items are not yet available to ship,
+they should not be offered as exchange options to customers.
+
+## How to Set It Up
+
+For setup instructions, contact your Redo Customer Success Manager at
+**support@getredo.com**.
+
+<IntegrationSupport integrationProvider="Purple Dot" />


### PR DESCRIPTION
## Summary

- **CreditsYard** (Marketing & Loyalty): Issues return store credit as CreditsYard rewards instead of Shopify store credit
- **Purple Dot** (Other): Prevents preorder products from being selected as exchange items
- Adds Marketing & Loyalty and Other Integrations navigation groups with overview pages

## Test plan

- [ ] Run `bazel run docs` and verify both new pages render correctly
- [ ] Check that overview CardGroup tiles link to the correct pages
- [ ] Verify docs.json navigation shows the new groups and pages in the sidebar
- [ ] Confirm the IntegrationSupport snippet renders properly on each page

🤖 Generated with [Claude Code](https://claude.com/claude-code)