### PR TITLE
Add cart_context to custom events public API request schema

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -1541,6 +1541,39 @@ components:
           description: ISO 8601 timestamp when the event occurred. Defaults to current time if not provided.
           format: date-time
           type: string
+        cart_context:
+          description: Cart context for product recommendations in triggered emails. If not provided, no cart-aware recommendations will be made.
+          nullable: true
+          type: object
+          properties:
+            existingCartId:
+              description: The ID of an existing cart to use for recommendations.
+              type: string
+              nullable: true
+            productIdsForRecommendations:
+              description: Product IDs to use as the basis for recommendations.
+              type: array
+              items:
+                type: string
+            alreadyInCart:
+              description: Items already in the customer's cart.
+              type: array
+              items:
+                type: object
+                properties:
+                  productId:
+                    type: string
+                  variantId:
+                    type: string
+                  quantity:
+                    type: number
+                required:
+                  - productId
+                  - variantId
+          required:
+            - existingCartId
+            - productIdsForRecommendations
+            - alreadyInCart
       required:
         - event_name
       title: Custom Event Request

--- a/redo/api-schema/src/schema/custom-event-request.schema.yaml
+++ b/redo/api-schema/src/schema/custom-event-request.schema.yaml
@@ -19,6 +19,39 @@ properties:
     description: ISO 8601 timestamp when the event occurred. Defaults to current time if not provided.
     format: date-time
     type: string
+  cart_context:
+    description: Cart context for product recommendations in triggered emails. If not provided, no cart-aware recommendations will be made.
+    nullable: true
+    type: object
+    properties:
+      existingCartId:
+        description: The ID of an existing cart to use for recommendations.
+        type: string
+        nullable: true
+      productIdsForRecommendations:
+        description: Product IDs to use as the basis for recommendations.
+        type: array
+        items:
+          type: string
+      alreadyInCart:
+        description: Items already in the customer's cart.
+        type: array
+        items:
+          type: object
+          properties:
+            productId:
+              type: string
+            variantId:
+              type: string
+            quantity:
+              type: number
+          required:
+            - productId
+            - variantId
+    required:
+      - existingCartId
+      - productIdsForRecommendations
+      - alreadyInCart
 required:
   - event_name
 title: Custom Event Request


### PR DESCRIPTION
Reflects the cart context support added in redo-app for product recommendations in triggered emails.

<img width="581" height="848" alt="Screenshot 2026-03-07 at 12 19 10 AM" src="https://github.com/user-attachments/assets/7e92e7e8-9016-47e4-a52a-759620db96e1" />
