### PR TITLE
RET2-1247: Add dropoffs field to return response schema

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -2179,7 +2179,7 @@ components:
           title: Shipment Group ID
           type: string
         provider:
-          description: Merchant-facing dropoff provider name (e.g. "FedEx Easy Returns", "Virtual")
+          description: Dropoff provider name (e.g. "FedEx Easy Returns", "Virtual")
           title: Provider
           type: string
         qrCode:

--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -2171,6 +2171,30 @@ components:
           type: string
       title: Return Shipment
       type: object
+    return-dropoff.schema:
+      description: Dropoff entry for returns using QR-code-based drop-off methods (e.g. BlueYonder/FedEx Easy Returns)
+      properties:
+        shipmentGroupId:
+          description: ID of the shipment group this dropoff belongs to
+          title: Shipment Group ID
+          type: string
+        provider:
+          description: Dropoff provider identifier (e.g. "blueyonder", "VIRTUAL")
+          title: Provider
+          type: string
+        qrCode:
+          description: Raw QR code data
+          title: QR Code
+          type: string
+        qrCodeUrl:
+          description: URL to a rendered QR code image
+          title: QR Code URL
+          type: string
+      required:
+        - shipmentGroupId
+        - provider
+      title: Return Dropoff
+      type: object
     return-status.schema:
       description: |
         Return status.
@@ -2647,6 +2671,12 @@ components:
           items:
             $ref: '#/components/schemas/return-shipment.schema'
           title: Shipments
+          type: array
+        dropoffs:
+          description: Array of QR-code-based dropoff entries for returns using drop-off methods such as BlueYonder/FedEx Easy Returns. Empty for standard label-based returns.
+          items:
+            $ref: '#/components/schemas/return-dropoff.schema'
+          title: Dropoffs
           type: array
         shopifyOrderIds:
           description: Array of Shopify order IDs (deprecated, use externalOrderIds)

--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -2179,7 +2179,7 @@ components:
           title: Shipment Group ID
           type: string
         provider:
-          description: Dropoff provider identifier (e.g. "blueyonder", "VIRTUAL")
+          description: Merchant-facing dropoff provider name (e.g. "FedEx Easy Returns", "Virtual")
           title: Provider
           type: string
         qrCode:

--- a/redo/api-schema/src/schema/return-dropoff.schema.yaml
+++ b/redo/api-schema/src/schema/return-dropoff.schema.yaml
@@ -6,7 +6,7 @@ properties:
     title: Shipment Group ID
     type: string
   provider:
-    description: Merchant-facing dropoff provider name (e.g. "FedEx Easy Returns", "Virtual")
+    description: Dropoff provider name (e.g. "FedEx Easy Returns", "Virtual")
     title: Provider
     type: string
   qrCode:

--- a/redo/api-schema/src/schema/return-dropoff.schema.yaml
+++ b/redo/api-schema/src/schema/return-dropoff.schema.yaml
@@ -6,7 +6,7 @@ properties:
     title: Shipment Group ID
     type: string
   provider:
-    description: Dropoff provider identifier (e.g. "blueyonder", "VIRTUAL")
+    description: Merchant-facing dropoff provider name (e.g. "FedEx Easy Returns", "Virtual")
     title: Provider
     type: string
   qrCode:

--- a/redo/api-schema/src/schema/return-dropoff.schema.yaml
+++ b/redo/api-schema/src/schema/return-dropoff.schema.yaml
@@ -1,0 +1,24 @@
+# $schema: https://json-schema.org/draft/2020-12/schema#
+description: Dropoff entry for returns using QR-code-based drop-off methods (e.g. BlueYonder/FedEx Easy Returns)
+properties:
+  shipmentGroupId:
+    description: ID of the shipment group this dropoff belongs to
+    title: Shipment Group ID
+    type: string
+  provider:
+    description: Dropoff provider identifier (e.g. "blueyonder", "VIRTUAL")
+    title: Provider
+    type: string
+  qrCode:
+    description: Raw QR code data
+    title: QR Code
+    type: string
+  qrCodeUrl:
+    description: URL to a rendered QR code image
+    title: QR Code URL
+    type: string
+required:
+  - shipmentGroupId
+  - provider
+title: Return Dropoff
+type: object

--- a/redo/api-schema/src/schema/return-read.schema.yaml
+++ b/redo/api-schema/src/schema/return-read.schema.yaml
@@ -396,6 +396,12 @@ properties:
       $ref: ./return-shipment.schema.yaml
     title: Shipments
     type: array
+  dropoffs:
+    description: Array of QR-code-based dropoff entries for returns using drop-off methods such as BlueYonder/FedEx Easy Returns. Empty for standard label-based returns.
+    items:
+      $ref: ./return-dropoff.schema.yaml
+    title: Dropoffs
+    type: array
   shopifyOrderIds:
     description: Array of Shopify order IDs (deprecated, use externalOrderIds)
     items:


### PR DESCRIPTION
## Summary

- Adds \`return-dropoff.schema.yaml\` — a new schema for QR-code-based drop-off returns (e.g. BlueYonder/FedEx Easy Returns)
- Adds \`dropoffs\` array field to the return read schema, parallel to \`shipments\`
- Regenerated \`openapi.yaml\` via \`bazel run openapi_gen\`

The \`dropoffs\` field exposes QR code data for returns that use drop-off methods instead of traditional shipping labels. Previously these returns had \`shipments: []\` with no way to access the QR code. Each entry includes \`shipmentGroupId\`, \`provider\`, \`qrCode\`, and \`qrCodeUrl\`.

## Test plan

- [ ] Verify \`openapi.yaml\` contains \`return-dropoff.schema\` and \`dropoffs\` field on return response
- [ ] Validate schema: \`bazel run docs -- openapi-check api-schema/openapi.yaml\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)