### PR TITLE
docs: update API key instructions to self-service flow

### DIFF
--- a/redo/docs/api-reference/loop-compatible-api.mdx
+++ b/redo/docs/api-reference/loop-compatible-api.mdx
@@ -86,4 +86,6 @@ When making requests to endpoints with `:return_id` in the path, you can identif
 
 ## Credentials
 
-Contact [support@getredo.com](mailto:support@getredo.com) to receive an API key for your Redo account.
+To create an API token, log in to your [Redo Dashboard](https://app.getredo.com), go to **Settings** → **Developer**, and click **Add API Client**. Copy the generated API secret and use it as a Bearer token in the `Authorization` header of your requests.
+
+See the [Authentication](/docs/api-reference/authentication) page for full details.

--- a/redo/docs/guides/integrations/custom-returns-integration.mdx
+++ b/redo/docs/guides/integrations/custom-returns-integration.mdx
@@ -364,8 +364,7 @@ must conform to this schema for successful synchronization.
 
 <Steps>
   <Step title="Get API Credentials">
-    Contact [support@getredo.com](mailto:support@getredo.com) to receive your
-    API key and endpoint URL
+    Log in to your [Redo Dashboard](https://app.getredo.com), go to **Settings** → **Developer**, and click **Add API Client** to generate your API secret. See [Authentication](/docs/api-reference/authentication) for details.
   </Step>
   <Step title="Map Your Order Data">
     Transform your order data to match the required schema


### PR DESCRIPTION
## Summary
- Replace outdated "contact support@getredo.com for an API key" wording with self-service instructions
- Merchants can now go to **Settings → Developer → Add API Client** in the Redo Dashboard to generate their own API secret
- Updated `loop-compatible-api.mdx` and `custom-returns-integration.mdx` to point to the existing Authentication page

## Test plan
- [ ] Verify the Loop-Compatible API page renders the updated Credentials section correctly
- [ ] Verify the Custom Returns Integration guide shows the updated "Get API Credentials" step
- [ ] Confirm links to the Authentication page resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)