### PR TITLE
feat: add OpenAPI docs for inventory levels endpoints

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -43,6 +43,7 @@ tags:
   - name: Customer Portal
   - name: Customer Subscriptions
   - name: Customers
+  - name: Inventory Levels
   - name: Invoices
   - name: Merchant Admin
   - name: Orders
@@ -663,6 +664,88 @@ paths:
       tags:
         - Customers
     summary: Customers
+  /stores/{storeId}/inventory-levels:
+    description: Inventory levels for a store.
+    get:
+      description: List inventory levels, representing the aggregate quantity of a product at a specific location. Sorted by most recently updated first.
+      operationId: Inventory levels list
+      parameters:
+        - $ref: '#/components/parameters/page-continue.param'
+        - $ref: '#/components/parameters/page-size.param'
+        - $ref: '#/components/parameters/location-id.param'
+        - $ref: '#/components/parameters/product-id.param'
+        - $ref: '#/components/parameters/sku.param'
+        - $ref: '#/components/parameters/updated-at-min.param'
+        - $ref: '#/components/parameters/updated-at-max.param'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  inventory_levels:
+                    items:
+                      $ref: '#/components/schemas/inventory-level-list.schema'
+                    type: array
+                required:
+                  - inventory_levels
+                type: object
+          description: Success
+          headers:
+            X-Page-Next:
+              $ref: '#/components/headers/page-next.header'
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/error.schema'
+          description: Error
+      security:
+        - Bearer: []
+      summary: List Inventory Levels
+      tags:
+        - Inventory Levels
+    parameters:
+      - $ref: '#/components/parameters/store-id.param'
+    summary: Inventory Levels
+  /stores/{storeId}/inventory-levels/{inventoryLevelId}:
+    description: Single inventory level.
+    get:
+      description: Get a single inventory level by ID. Returns additional detail fields including external IDs, creation timestamp, product UPC, and image URL.
+      operationId: Inventory level get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  inventory_level:
+                    $ref: '#/components/schemas/inventory-level-detail.schema'
+                required:
+                  - inventory_level
+                type: object
+          description: Success
+        '404':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/error.schema'
+          description: Inventory level not found
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/error.schema'
+          description: Error
+      security:
+        - Bearer: []
+      summary: Get Inventory Level
+      tags:
+        - Inventory Levels
+    parameters:
+      - $ref: '#/components/parameters/store-id.param'
+      - $ref: '#/components/parameters/inventory-level-id.param'
+    summary: Inventory Level
   /invoices/pending/items.csv:
     description: Return invoice CSV file.
     get:
@@ -1757,6 +1840,67 @@ components:
       schema:
         example: 64e5a8a1af49a89df37e4ee7
         type: string
+    page-continue.param:
+      description: Page marker, from X-Page-Next header
+      example: 64df700931a04885276c3364
+      in: header
+      name: X-Page-Continue
+      schema:
+        type: string
+    page-size.param:
+      description: Page size, defaults to 20
+      example: 20
+      in: header
+      name: X-Page-Size
+      schema:
+        maximum: 500
+        minimum: 1
+        type: integer
+    location-id.param:
+      description: Filter by location ID (e.g. `loc_...`)
+      example: loc_4d8e1a2b3c
+      in: query
+      name: location_id
+      schema:
+        type: string
+    product-id.param:
+      description: Filter by product ID (e.g. `prd_...`)
+      example: prd_1a2b3c4d5e
+      in: query
+      name: product_id
+      schema:
+        type: string
+    sku.param:
+      description: Filter by product SKU
+      example: TSH-BLK-M
+      in: query
+      name: sku
+      schema:
+        type: string
+    updated-at-min.param:
+      description: Minimum updated time, inclusive
+      example: '2000-01-01T00:00:00Z'
+      in: query
+      name: updated_at_min
+      schema:
+        format: date-time
+        type: string
+    updated-at-max.param:
+      description: Maximum updated time, exclusive
+      example: '2000-02-01T00:00:00Z'
+      in: query
+      name: updated_at_max
+      schema:
+        format: date-time
+        type: string
+    inventory-level-id.param:
+      description: Inventory level ID
+      in: path
+      name: inventoryLevelId
+      required: true
+      schema:
+        example: li_9b2c4d6e8f
+        type: string
     invoice-id.param:
       description: Invoice ID
       in: path
@@ -1786,38 +1930,6 @@ components:
       required: true
       schema:
         example: 64e4d5e837572a4813b73e40
-        type: string
-    page-continue.param:
-      description: Page marker, from X-Page-Next header
-      example: 64df700931a04885276c3364
-      in: header
-      name: X-Page-Continue
-      schema:
-        type: string
-    page-size.param:
-      description: Page size, defaults to 20
-      example: 20
-      in: header
-      name: X-Page-Size
-      schema:
-        maximum: 500
-        minimum: 1
-        type: integer
-    updated-at-max.param:
-      description: Maximum updated time, exclusive
-      example: '2000-02-01T00:00:00Z'
-      in: query
-      name: updated_at_max
-      schema:
-        format: date-time
-        type: string
-    updated-at-min.param:
-      description: Minimum updated time, inclusive
-      example: '2000-01-01T00:00:00Z'
-      in: query
-      name: updated_at_min
-      schema:
-        format: date-time
         type: string
     shopify-order-name:
       description: Shopify specific order name
@@ -2492,6 +2604,137 @@ components:
         - created
       title: Customer Upsert Response
       type: object
+    inventory-level-product-summary.schema:
+      description: Product summary in an inventory level response.
+      properties:
+        id:
+          description: Prefixed product ID (`prd_...`).
+          example: prd_1a2b3c4d5e
+          type: string
+        title:
+          description: Product title including variant options.
+          example: Classic Cotton T-Shirt - Black / M
+          type: string
+        sku:
+          description: Stock keeping unit.
+          example: TSH-BLK-M
+          nullable: true
+          type: string
+      required:
+        - id
+        - title
+        - sku
+      title: Inventory Level Product Summary
+      type: object
+    inventory-level-location.schema:
+      description: Location summary in an inventory level response.
+      properties:
+        id:
+          description: Prefixed location ID (`loc_...`).
+          example: loc_4d8e1a2b3c
+          type: string
+        name:
+          description: Location name.
+          example: East Coast Warehouse
+          type: string
+      required:
+        - id
+        - name
+      title: Inventory Level Location
+      type: object
+    inventory-level-list.schema:
+      description: Inventory level list item.
+      properties:
+        id:
+          description: Prefixed inventory level ID (`li_...`).
+          example: li_9b2c4d6e8f
+          type: string
+        product:
+          $ref: '#/components/schemas/inventory-level-product-summary.schema'
+        location:
+          $ref: '#/components/schemas/inventory-level-location.schema'
+        quantity:
+          description: On-hand quantity.
+          example: 1250
+          type: integer
+        available:
+          description: Available quantity (`quantity - committed - reserved`).
+          example: 1100
+          type: integer
+        committed:
+          description: Allocated to unfulfilled orders.
+          example: 100
+          type: integer
+        reserved:
+          description: Held (damaged, QC, etc.).
+          example: 50
+          type: integer
+        buildable:
+          description: Can be assembled from BOM components.
+          example: 0
+          type: integer
+        total_available:
+          description: Total available (`available + buildable`).
+          example: 1100
+          type: integer
+        updated_at:
+          description: Last updated timestamp (ISO 8601).
+          example: '2026-03-31T18:45:00.000Z'
+          format: date-time
+          type: string
+      required:
+        - id
+        - product
+        - location
+        - quantity
+        - available
+        - committed
+        - reserved
+        - buildable
+        - total_available
+        - updated_at
+      title: Inventory Level
+      type: object
+    inventory-level-product-detail.schema:
+      description: Product detail in an inventory level detail response.
+      allOf:
+        - $ref: '#/components/schemas/inventory-level-product-summary.schema'
+        - properties:
+            upc:
+              description: Universal product code.
+              example: '012345678901'
+              nullable: true
+              type: string
+            image_url:
+              description: URL of the product's primary image.
+              example: https://cdn.example.com/tshirt-blk-m.jpg
+              nullable: true
+              type: string
+          type: object
+      title: Inventory Level Product Detail
+    inventory-level-detail.schema:
+      description: Inventory level detail.
+      allOf:
+        - $ref: '#/components/schemas/inventory-level-list.schema'
+        - properties:
+            product:
+              $ref: '#/components/schemas/inventory-level-product-detail.schema'
+            external_ids:
+              description: External system IDs (e.g. Shopify inventory item GID).
+              example:
+                shopify: gid://shopify/InventoryItem/12345678
+              nullable: true
+              type: object
+            created_at:
+              description: Creation timestamp (ISO 8601).
+              example: '2025-11-01T10:00:00.000Z'
+              format: date-time
+              type: string
+          required:
+            - external_ids
+            - created_at
+          type: object
+      title: Inventory Level Detail
     invoice.schema:
       description: Schema for an invoice.
       properties:

--- a/redo/api-schema/src/openapi.yaml
+++ b/redo/api-schema/src/openapi.yaml
@@ -49,6 +49,7 @@ tags:
   - name: Customer Portal
   - name: Customer Subscriptions
   - name: Customers
+  - name: Inventory Levels
   - name: Invoices
   - name: Merchant Admin
   - name: Orders
@@ -75,6 +76,11 @@ paths:
     { $ref: path/customer-subscriptions.path.yaml }
   # Customers
   /stores/{storeId}/customers: { $ref: path/customers.path.yaml }
+  # Inventory Levels
+  /stores/{storeId}/inventory-levels:
+    { $ref: path/inventory-levels.path.yaml }
+  /stores/{storeId}/inventory-levels/{inventoryLevelId}:
+    { $ref: path/inventory-level.path.yaml }
   # Invoices
   /invoices/pending/items.csv: { $ref: path/invoice-pending-csv.path.yaml }
   /invoices/{invoiceId}/items.csv: { $ref: path/invoice-csv.path.yaml }

--- a/redo/api-schema/src/param/inventory-level-id.param.yaml
+++ b/redo/api-schema/src/param/inventory-level-id.param.yaml
@@ -1,0 +1,7 @@
+description: Inventory level ID
+in: path
+name: inventoryLevelId
+required: true
+schema:
+  example: li_9b2c4d6e8f
+  type: string

--- a/redo/api-schema/src/param/location-id.param.yaml
+++ b/redo/api-schema/src/param/location-id.param.yaml
@@ -1,0 +1,5 @@
+description: Filter by location ID (e.g. `loc_...`)
+example: loc_4d8e1a2b3c
+in: query
+name: location_id
+schema: { type: string }

--- a/redo/api-schema/src/param/product-id.param.yaml
+++ b/redo/api-schema/src/param/product-id.param.yaml
@@ -1,0 +1,5 @@
+description: Filter by product ID (e.g. `prd_...`)
+example: prd_1a2b3c4d5e
+in: query
+name: product_id
+schema: { type: string }

--- a/redo/api-schema/src/param/sku.param.yaml
+++ b/redo/api-schema/src/param/sku.param.yaml
@@ -1,0 +1,5 @@
+description: Filter by product SKU
+example: TSH-BLK-M
+in: query
+name: sku
+schema: { type: string }

--- a/redo/api-schema/src/path/inventory-level.path.yaml
+++ b/redo/api-schema/src/path/inventory-level.path.yaml
@@ -1,0 +1,35 @@
+description: Single inventory level.
+get:
+  description: >-
+    Get a single inventory level by ID. Returns additional detail fields
+    including external IDs, creation timestamp, product UPC, and image URL.
+  operationId: Inventory level get
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            properties:
+              inventory_level:
+                $ref: ../schema/inventory-level-detail.schema.yaml
+            required: [inventory_level]
+            type: object
+      description: Success
+    "404":
+      content:
+        application/problem+json:
+          schema: { $ref: ../schema/error.schema.yaml }
+      description: Inventory level not found
+    default:
+      content:
+        application/problem+json:
+          schema: { $ref: ../schema/error.schema.yaml }
+      description: Error
+  security:
+    - Bearer: []
+  summary: Get Inventory Level
+  tags: [Inventory Levels]
+parameters:
+  - { $ref: ../param/store-id.param.yaml }
+  - { $ref: ../param/inventory-level-id.param.yaml }
+summary: Inventory Level

--- a/redo/api-schema/src/path/inventory-levels.path.yaml
+++ b/redo/api-schema/src/path/inventory-levels.path.yaml
@@ -1,0 +1,40 @@
+description: Inventory levels for a store.
+get:
+  description: >-
+    List inventory levels, representing the aggregate quantity of a product at a
+    specific location. Sorted by most recently updated first.
+  operationId: Inventory levels list
+  parameters:
+    - { $ref: ../param/page-continue.param.yaml }
+    - { $ref: ../param/page-size.param.yaml }
+    - { $ref: ../param/location-id.param.yaml }
+    - { $ref: ../param/product-id.param.yaml }
+    - { $ref: ../param/sku.param.yaml }
+    - { $ref: ../param/updated-at-min.param.yaml }
+    - { $ref: ../param/updated-at-max.param.yaml }
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            properties:
+              inventory_levels:
+                items: { $ref: ../schema/inventory-level-list.schema.yaml }
+                type: array
+            required: [inventory_levels]
+            type: object
+      description: Success
+      headers:
+        X-Page-Next: { $ref: ../header/page-next.header.yaml }
+    default:
+      content:
+        application/problem+json:
+          schema: { $ref: ../schema/error.schema.yaml }
+      description: Error
+  security:
+    - Bearer: []
+  summary: List Inventory Levels
+  tags: [Inventory Levels]
+parameters:
+  - { $ref: ../param/store-id.param.yaml }
+summary: Inventory Levels

--- a/redo/api-schema/src/schema/inventory-level-detail.schema.yaml
+++ b/redo/api-schema/src/schema/inventory-level-detail.schema.yaml
@@ -1,0 +1,19 @@
+description: Inventory level detail.
+allOf:
+  - $ref: inventory-level-list.schema.yaml
+  - properties:
+      product:
+        $ref: inventory-level-product-detail.schema.yaml
+      external_ids:
+        description: External system IDs (e.g. Shopify inventory item GID).
+        example: { shopify: "gid://shopify/InventoryItem/12345678" }
+        nullable: true
+        type: object
+      created_at:
+        description: Creation timestamp (ISO 8601).
+        example: "2025-11-01T10:00:00.000Z"
+        format: date-time
+        type: string
+    required: [external_ids, created_at]
+    type: object
+title: Inventory Level Detail

--- a/redo/api-schema/src/schema/inventory-level-list.schema.yaml
+++ b/redo/api-schema/src/schema/inventory-level-list.schema.yaml
@@ -1,0 +1,52 @@
+description: Inventory level list item.
+properties:
+  id:
+    description: Prefixed inventory level ID (`li_...`).
+    example: li_9b2c4d6e8f
+    type: string
+  product:
+    $ref: inventory-level-product-summary.schema.yaml
+  location:
+    $ref: inventory-level-location.schema.yaml
+  quantity:
+    description: On-hand quantity.
+    example: 1250
+    type: integer
+  available:
+    description: Available quantity (`quantity - committed - reserved`).
+    example: 1100
+    type: integer
+  committed:
+    description: Allocated to unfulfilled orders.
+    example: 100
+    type: integer
+  reserved:
+    description: Held (damaged, QC, etc.).
+    example: 50
+    type: integer
+  buildable:
+    description: Can be assembled from BOM components.
+    example: 0
+    type: integer
+  total_available:
+    description: Total available (`available + buildable`).
+    example: 1100
+    type: integer
+  updated_at:
+    description: Last updated timestamp (ISO 8601).
+    example: "2026-03-31T18:45:00.000Z"
+    format: date-time
+    type: string
+required:
+  - id
+  - product
+  - location
+  - quantity
+  - available
+  - committed
+  - reserved
+  - buildable
+  - total_available
+  - updated_at
+title: Inventory Level
+type: object

--- a/redo/api-schema/src/schema/inventory-level-location.schema.yaml
+++ b/redo/api-schema/src/schema/inventory-level-location.schema.yaml
@@ -1,0 +1,13 @@
+description: Location summary in an inventory level response.
+properties:
+  id:
+    description: Prefixed location ID (`loc_...`).
+    example: loc_4d8e1a2b3c
+    type: string
+  name:
+    description: Location name.
+    example: East Coast Warehouse
+    type: string
+required: [id, name]
+title: Inventory Level Location
+type: object

--- a/redo/api-schema/src/schema/inventory-level-product-detail.schema.yaml
+++ b/redo/api-schema/src/schema/inventory-level-product-detail.schema.yaml
@@ -1,0 +1,16 @@
+description: Product detail in an inventory level detail response.
+allOf:
+  - $ref: inventory-level-product-summary.schema.yaml
+  - properties:
+      upc:
+        description: Universal product code.
+        example: "012345678901"
+        nullable: true
+        type: string
+      image_url:
+        description: URL of the product's primary image.
+        example: https://cdn.example.com/tshirt-blk-m.jpg
+        nullable: true
+        type: string
+    type: object
+title: Inventory Level Product Detail

--- a/redo/api-schema/src/schema/inventory-level-product-summary.schema.yaml
+++ b/redo/api-schema/src/schema/inventory-level-product-summary.schema.yaml
@@ -1,0 +1,18 @@
+description: Product summary in an inventory level response.
+properties:
+  id:
+    description: Prefixed product ID (`prd_...`).
+    example: prd_1a2b3c4d5e
+    type: string
+  title:
+    description: Product title including variant options.
+    example: Classic Cotton T-Shirt - Black / M
+    type: string
+  sku:
+    description: Stock keeping unit.
+    example: TSH-BLK-M
+    nullable: true
+    type: string
+required: [id, title, sku]
+title: Inventory Level Product Summary
+type: object


### PR DESCRIPTION
## Summary
- Add OpenAPI documentation for the new inventory levels public API endpoints
- `GET /stores/{storeId}/inventory-levels` — list with cursor pagination and filters (location_id, product_id, sku, updated_at_min/max)
- `GET /stores/{storeId}/inventory-levels/{inventoryLevelId}` — detail with external_ids, created_at, product upc/image_url
- Reuses existing pagination params/headers, adds new params for location_id, product_id, sku, and inventory-level-id

## Test plan
- [x] `bazel run openapi_gen` succeeds
- [x] `openapi-check` validation passes
- [x] Mintlify dev server renders the new endpoints under "Inventory Levels" tag