### PR TITLE
docs: add Import Returns API endpoint

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -1663,7 +1663,25 @@ paths:
   /stores/{storeId}/returns/bulk:
     description: Bulk create external returns without requiring an existing order.
     post:
-      description: Create returns in bulk by referencing products via platform-specific external IDs (e.g. Shopify GIDs). Products are resolved against the product catalog. Supports up to 100 returns per request with per-item error reporting. Designed for external systems (warehouse management, ERPs, offline POS) that need to push returns into Redo without going through the customer portal flow.
+      description: |-
+        Create **external** returns in bulk by referencing products via platform-specific external IDs (e.g. Shopify GIDs). Products are resolved against the product catalog. Supports up to 100 returns per request with per-item error reporting.
+
+        **How this differs from Create Return (`POST /stores/{storeId}/returns`):**
+        - **No order required.** The standard endpoint creates a return against an
+          existing order using line item IDs. This endpoint resolves products
+          directly from the product catalog by external ID and provider.
+
+        - **External source.** Returns created through this endpoint are marked with
+          `source: "external"` rather than `source: "redo"`. This distinction
+          is used downstream to skip flows that don't apply to externally-managed
+          returns (e.g. customer notifications, Shopify refund sync).
+
+        - **Immediately processed.** Returns are created with `provision: "processed"`,
+          meaning no customer portal flow, no label generation, and no payment holds.
+          The return is ready for warehouse intake on creation.
+
+
+        Designed for external systems (warehouse management, ERPs, offline POS) that need to push returns into Redo without going through the customer portal flow.
       operationId: Returns bulk create
       requestBody:
         content:

--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -1682,7 +1682,7 @@ paths:
 
 
         Designed for external systems (warehouse management, ERPs, offline POS) that need to push returns into Redo without going through the customer portal flow.
-      operationId: Returns bulk create
+      operationId: Bulk upload external returns
       requestBody:
         content:
           application/json:
@@ -1710,12 +1710,12 @@ paths:
           description: Error
       security:
         - Bearer: []
-      summary: Bulk Create Returns
+      summary: Bulk Upload External Returns
       tags:
         - Returns
     parameters:
       - $ref: '#/components/parameters/store-id.param'
-    summary: Bulk Returns
+    summary: Bulk Upload External Returns
   /stores/{storeId}/return-tags:
     description: Return tags for a store.
     get:

--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -1664,20 +1664,9 @@ paths:
     description: Import returns from external systems.
     post:
       description: |-
-        Import returns into Redo by referencing products via platform-specific external IDs (e.g. Shopify GIDs). Products are resolved against the product catalog. Supports up to 100 returns per request with per-item error reporting.
+        Import externally-created returns into Redo. Use this endpoint when the return originates outside of Redo — a warehouse scan, an ERP, a POS system, or a partner platform.
 
-        Use this endpoint when the return originates outside of Redo — a warehouse scan, an ERP, a POS system, or a partner platform. No order is required.
-
-        **How this differs from Create Return (`POST /stores/{storeId}/returns`):**
-        - **No order required.** Create Return creates a return against an
-          existing order using line item IDs. This endpoint resolves products
-          directly from the product catalog by external ID and provider.
-
-        - **No customer flow.** Returns are created ready for warehouse intake —
-          no customer portal, no label generation, and no payment holds.
-
-        - **External source.** Returns are tagged as externally-managed, which
-          skips flows like customer notifications and platform refund sync.
+        Products are referenced by their platform-specific external ID and resolved against the Redo product catalog. No order is required. Returns are created ready for warehouse intake. Supports up to 100 returns per request with per-item error reporting.
       operationId: Import returns
       requestBody:
         content:
@@ -5326,16 +5315,16 @@ components:
         - externalRMAResponses
     bulk-returns-request.schema:
       type: object
-      description: Bulk external return creation request body.
+      description: Import returns request body.
       properties:
         returns:
           type: array
           minItems: 1
           maxItems: 100
-          description: Array of external returns to create (max 100).
+          description: Array of returns to import (max 100).
           items:
             type: object
-            description: A single external return to create.
+            description: A single return to import.
             properties:
               products:
                 type: array
@@ -5346,7 +5335,7 @@ components:
                   properties:
                     externalId:
                       type: string
-                      description: Platform-specific variant/product identifier (e.g. Shopify GID like 'gid://shopify/ProductVariant/12345'). Resolved against the product catalog.
+                      description: Platform-specific variant/product identifier. Resolved against the Redo product catalog.
                     quantity:
                       type: integer
                       minimum: 1

--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -1660,6 +1660,44 @@ paths:
     parameters:
       - $ref: '#/components/parameters/store-id.param'
     summary: Returns
+  /stores/{storeId}/returns/bulk:
+    description: Bulk create external returns without requiring an existing order.
+    post:
+      description: Create returns in bulk by referencing products via platform-specific external IDs (e.g. Shopify GIDs). Products are resolved against the product catalog. Supports up to 100 returns per request with per-item error reporting. Designed for external systems (warehouse management, ERPs, offline POS) that need to push returns into Redo without going through the customer portal flow.
+      operationId: Returns bulk create
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/bulk-returns-request.schema'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bulk-returns-response.schema'
+          description: Batch processed. Check individual results for per-item status. Some items may have succeeded while others failed.
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error.schema'
+          description: Invalid request body or team not configured for product catalog operations.
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/error.schema'
+          description: Error
+      security:
+        - Bearer: []
+      summary: Bulk Create Returns
+      tags:
+        - Returns
+    parameters:
+      - $ref: '#/components/parameters/store-id.param'
+    summary: Bulk Returns
   /stores/{storeId}/return-tags:
     description: Return tags for a store.
     get:
@@ -5272,6 +5310,225 @@ components:
       required:
         - return
         - externalRMAResponses
+    bulk-returns-request.schema:
+      type: object
+      description: Bulk external return creation request body.
+      properties:
+        returns:
+          type: array
+          minItems: 1
+          maxItems: 100
+          description: Array of external returns to create (max 100).
+          items:
+            type: object
+            description: A single external return to create.
+            properties:
+              products:
+                type: array
+                minItems: 1
+                description: Products being returned (at least 1).
+                items:
+                  type: object
+                  properties:
+                    externalId:
+                      type: string
+                      description: Platform-specific variant/product identifier (e.g. Shopify GID like 'gid://shopify/ProductVariant/12345'). Resolved against the product catalog.
+                    quantity:
+                      type: integer
+                      minimum: 1
+                      description: Number of units to return.
+                    provider:
+                      type: string
+                      enum:
+                        - shopify
+                        - bigcommerce
+                        - commentsold
+                        - commerce-cloud
+                        - cin7-omni
+                        - cin7-core
+                        - amazon
+                        - ebay
+                      description: Ecommerce platform the externalId belongs to.
+                    sku:
+                      type: string
+                      description: Override SKU (uses catalog value if omitted).
+                    barcode:
+                      type: string
+                      description: Override barcode (uses catalog value if omitted).
+                    productTitle:
+                      type: string
+                      description: Override product title (uses catalog value if omitted).
+                    variantTitle:
+                      type: string
+                      description: Override variant title (uses catalog value if omitted).
+                    reason:
+                      type: string
+                      description: Return reason.
+                    condition:
+                      type: string
+                      description: Item condition.
+                  required:
+                    - externalId
+                    - quantity
+                    - provider
+              customer:
+                type: object
+                description: Optional customer information.
+                properties:
+                  firstName:
+                    type: string
+                  lastName:
+                    type: string
+                  email:
+                    type: string
+                    format: email
+              externalReferenceId:
+                type: string
+                description: Merchant's own return/RMA ID. Stored on the return so it's scannable at warehouse intake.
+              trackingNumber:
+                type: string
+                description: Carrier tracking number for the inbound return shipment.
+              carrier:
+                type: string
+                description: Carrier name for the tracking number (e.g. 'USPS', 'UPS').
+              notes:
+                type: string
+                description: Internal notes.
+              idempotencyKey:
+                type: string
+                description: Idempotency key to prevent duplicate return creation on retry.
+              currency:
+                type: string
+                description: ISO 4217 currency code (defaults to USD).
+                examples:
+                  - USD
+                  - GBP
+                  - EUR
+              shippingAddress:
+                type: object
+                description: Customer's shipping address.
+                properties:
+                  line1:
+                    type: string
+                    description: Street address line 1.
+                  line2:
+                    type: string
+                    description: Street address line 2.
+                  city:
+                    type: string
+                    description: City.
+                  state:
+                    type: string
+                    description: State or province code.
+                  postalCode:
+                    type: string
+                    description: Postal/ZIP code.
+                  country:
+                    type: string
+                    description: ISO 3166-1 alpha-2 country code.
+                  name:
+                    type: string
+                    description: Recipient or location name.
+                  phone:
+                    type: string
+                    description: Phone number.
+                required:
+                  - line1
+                  - city
+                  - country
+              merchantAddress:
+                type: object
+                description: Merchant return destination address.
+                properties:
+                  line1:
+                    type: string
+                    description: Street address line 1.
+                  line2:
+                    type: string
+                    description: Street address line 2.
+                  city:
+                    type: string
+                    description: City.
+                  state:
+                    type: string
+                    description: State or province code.
+                  postalCode:
+                    type: string
+                    description: Postal/ZIP code.
+                  country:
+                    type: string
+                    description: ISO 3166-1 alpha-2 country code.
+                  name:
+                    type: string
+                    description: Recipient or location name.
+                  phone:
+                    type: string
+                    description: Phone number.
+                required:
+                  - line1
+                  - city
+                  - country
+            required:
+              - products
+      required:
+        - returns
+    bulk-returns-response.schema:
+      type: object
+      description: Bulk external return creation response.
+      properties:
+        totalCount:
+          type: integer
+          description: Total number of returns in the request.
+        processedCount:
+          type: integer
+          description: Number of returns successfully created.
+        errorCount:
+          type: integer
+          description: Number of returns that failed.
+        results:
+          type: array
+          description: Per-item results in the same order as the request.
+          items:
+            oneOf:
+              - type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - created
+                  index:
+                    type: integer
+                    description: Zero-based index into the request array.
+                  returnId:
+                    type: string
+                    description: ID of the created return.
+                required:
+                  - status
+                  - index
+                  - returnId
+              - type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - error
+                  index:
+                    type: integer
+                    description: Zero-based index into the request array.
+                  error:
+                    type: string
+                    description: Error message.
+                required:
+                  - status
+                  - index
+                  - error
+            discriminator:
+              propertyName: status
+      required:
+        - totalCount
+        - processedCount
+        - errorCount
+        - results
     pill-theme.schema:
       description: Color theme used to render a tag pill in the UI.
       enum:

--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -1661,28 +1661,24 @@ paths:
       - $ref: '#/components/parameters/store-id.param'
     summary: Returns
   /stores/{storeId}/returns/bulk:
-    description: Bulk create external returns without requiring an existing order.
+    description: Import returns from external systems.
     post:
       description: |-
-        Create **external** returns in bulk by referencing products via platform-specific external IDs (e.g. Shopify GIDs). Products are resolved against the product catalog. Supports up to 100 returns per request with per-item error reporting.
+        Import returns into Redo by referencing products via platform-specific external IDs (e.g. Shopify GIDs). Products are resolved against the product catalog. Supports up to 100 returns per request with per-item error reporting.
+
+        Use this endpoint when the return originates outside of Redo — a warehouse scan, an ERP, a POS system, or a partner platform. No order is required.
 
         **How this differs from Create Return (`POST /stores/{storeId}/returns`):**
-        - **No order required.** The standard endpoint creates a return against an
+        - **No order required.** Create Return creates a return against an
           existing order using line item IDs. This endpoint resolves products
           directly from the product catalog by external ID and provider.
 
-        - **External source.** Returns created through this endpoint are marked with
-          `source: "external"` rather than `source: "redo"`. This distinction
-          is used downstream to skip flows that don't apply to externally-managed
-          returns (e.g. customer notifications, Shopify refund sync).
+        - **No customer flow.** Returns are created ready for warehouse intake —
+          no customer portal, no label generation, and no payment holds.
 
-        - **Immediately processed.** Returns are created with `provision: "processed"`,
-          meaning no customer portal flow, no label generation, and no payment holds.
-          The return is ready for warehouse intake on creation.
-
-
-        Designed for external systems (warehouse management, ERPs, offline POS) that need to push returns into Redo without going through the customer portal flow.
-      operationId: Bulk upload external returns
+        - **External source.** Returns are tagged as externally-managed, which
+          skips flows like customer notifications and platform refund sync.
+      operationId: Import returns
       requestBody:
         content:
           application/json:
@@ -1710,12 +1706,12 @@ paths:
           description: Error
       security:
         - Bearer: []
-      summary: Bulk Upload External Returns
+      summary: Import Returns
       tags:
         - Returns
     parameters:
       - $ref: '#/components/parameters/store-id.param'
-    summary: Bulk Upload External Returns
+    summary: Import Returns
   /stores/{storeId}/return-tags:
     description: Return tags for a store.
     get:

--- a/redo/api-schema/src/openapi.yaml
+++ b/redo/api-schema/src/openapi.yaml
@@ -109,6 +109,7 @@ paths:
   /returns/{returnId}/process: { $ref: path/return-process.path.yaml }
   /returns/{returnId}/status: { $ref: path/return-status.path.yaml }
   /stores/{storeId}/returns: { $ref: path/returns.path.yaml }
+  /stores/{storeId}/returns/bulk: { $ref: path/returns-bulk.path.yaml }
   # Return Tags
   /stores/{storeId}/return-tags: { $ref: path/return-tags.path.yaml }
   /stores/{storeId}/return-tags/{name}: { $ref: path/return-tag.path.yaml }

--- a/redo/api-schema/src/path/returns-bulk.path.yaml
+++ b/redo/api-schema/src/path/returns-bulk.path.yaml
@@ -25,7 +25,7 @@ post:
 
     Designed for external systems (warehouse management, ERPs, offline POS) that
     need to push returns into Redo without going through the customer portal flow.
-  operationId: Returns bulk create
+  operationId: Bulk upload external returns
   requestBody:
     content:
       application/json:
@@ -53,8 +53,8 @@ post:
       description: Error
   security:
     - Bearer: []
-  summary: Bulk Create Returns
+  summary: Bulk Upload External Returns
   tags: [Returns]
 parameters:
   - { $ref: ../param/store-id.param.yaml }
-summary: Bulk Returns
+summary: Bulk Upload External Returns

--- a/redo/api-schema/src/path/returns-bulk.path.yaml
+++ b/redo/api-schema/src/path/returns-bulk.path.yaml
@@ -1,0 +1,42 @@
+description: Bulk create external returns without requiring an existing order.
+post:
+  description: >-
+    Create returns in bulk by referencing products via platform-specific
+    external IDs (e.g. Shopify GIDs). Products are resolved against the
+    product catalog. Supports up to 100 returns per request with per-item
+    error reporting. Designed for external systems (warehouse management,
+    ERPs, offline POS) that need to push returns into Redo without going
+    through the customer portal flow.
+  operationId: Returns bulk create
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: ../schema/bulk-returns-request.schema.yaml
+    required: true
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: ../schema/bulk-returns-response.schema.yaml
+      description: >-
+        Batch processed. Check individual results for per-item status.
+        Some items may have succeeded while others failed.
+    "400":
+      content:
+        application/json:
+          schema: { $ref: ../schema/error.schema.yaml }
+      description: Invalid request body or team not configured for product catalog operations.
+    default:
+      content:
+        application/problem+json:
+          schema: { $ref: ../schema/error.schema.yaml }
+      description: Error
+  security:
+    - Bearer: []
+  summary: Bulk Create Returns
+  tags: [Returns]
+parameters:
+  - { $ref: ../param/store-id.param.yaml }
+summary: Bulk Returns

--- a/redo/api-schema/src/path/returns-bulk.path.yaml
+++ b/redo/api-schema/src/path/returns-bulk.path.yaml
@@ -1,12 +1,30 @@
 description: Bulk create external returns without requiring an existing order.
 post:
   description: >-
-    Create returns in bulk by referencing products via platform-specific
-    external IDs (e.g. Shopify GIDs). Products are resolved against the
-    product catalog. Supports up to 100 returns per request with per-item
-    error reporting. Designed for external systems (warehouse management,
-    ERPs, offline POS) that need to push returns into Redo without going
-    through the customer portal flow.
+    Create **external** returns in bulk by referencing products via
+    platform-specific external IDs (e.g. Shopify GIDs). Products are
+    resolved against the product catalog. Supports up to 100 returns per
+    request with per-item error reporting.
+
+
+    **How this differs from Create Return (`POST /stores/{storeId}/returns`):**
+
+    - **No order required.** The standard endpoint creates a return against an
+      existing order using line item IDs. This endpoint resolves products
+      directly from the product catalog by external ID and provider.
+
+    - **External source.** Returns created through this endpoint are marked with
+      `source: "external"` rather than `source: "redo"`. This distinction
+      is used downstream to skip flows that don't apply to externally-managed
+      returns (e.g. customer notifications, Shopify refund sync).
+
+    - **Immediately processed.** Returns are created with `provision: "processed"`,
+      meaning no customer portal flow, no label generation, and no payment holds.
+      The return is ready for warehouse intake on creation.
+
+
+    Designed for external systems (warehouse management, ERPs, offline POS) that
+    need to push returns into Redo without going through the customer portal flow.
   operationId: Returns bulk create
   requestBody:
     content:

--- a/redo/api-schema/src/path/returns-bulk.path.yaml
+++ b/redo/api-schema/src/path/returns-bulk.path.yaml
@@ -1,28 +1,15 @@
 description: Import returns from external systems.
 post:
   description: >-
-    Import returns into Redo by referencing products via platform-specific
-    external IDs (e.g. Shopify GIDs). Products are resolved against the
-    product catalog. Supports up to 100 returns per request with per-item
-    error reporting.
+    Import externally-created returns into Redo. Use this endpoint when
+    the return originates outside of Redo — a warehouse scan, an ERP, a
+    POS system, or a partner platform.
 
 
-    Use this endpoint when the return originates outside of Redo — a
-    warehouse scan, an ERP, a POS system, or a partner platform. No order
-    is required.
-
-
-    **How this differs from Create Return (`POST /stores/{storeId}/returns`):**
-
-    - **No order required.** Create Return creates a return against an
-      existing order using line item IDs. This endpoint resolves products
-      directly from the product catalog by external ID and provider.
-
-    - **No customer flow.** Returns are created ready for warehouse intake —
-      no customer portal, no label generation, and no payment holds.
-
-    - **External source.** Returns are tagged as externally-managed, which
-      skips flows like customer notifications and platform refund sync.
+    Products are referenced by their platform-specific external ID and
+    resolved against the Redo product catalog. No order is required.
+    Returns are created ready for warehouse intake. Supports up to 100
+    returns per request with per-item error reporting.
   operationId: Import returns
   requestBody:
     content:

--- a/redo/api-schema/src/path/returns-bulk.path.yaml
+++ b/redo/api-schema/src/path/returns-bulk.path.yaml
@@ -1,31 +1,29 @@
-description: Bulk create external returns without requiring an existing order.
+description: Import returns from external systems.
 post:
   description: >-
-    Create **external** returns in bulk by referencing products via
-    platform-specific external IDs (e.g. Shopify GIDs). Products are
-    resolved against the product catalog. Supports up to 100 returns per
-    request with per-item error reporting.
+    Import returns into Redo by referencing products via platform-specific
+    external IDs (e.g. Shopify GIDs). Products are resolved against the
+    product catalog. Supports up to 100 returns per request with per-item
+    error reporting.
+
+
+    Use this endpoint when the return originates outside of Redo — a
+    warehouse scan, an ERP, a POS system, or a partner platform. No order
+    is required.
 
 
     **How this differs from Create Return (`POST /stores/{storeId}/returns`):**
 
-    - **No order required.** The standard endpoint creates a return against an
+    - **No order required.** Create Return creates a return against an
       existing order using line item IDs. This endpoint resolves products
       directly from the product catalog by external ID and provider.
 
-    - **External source.** Returns created through this endpoint are marked with
-      `source: "external"` rather than `source: "redo"`. This distinction
-      is used downstream to skip flows that don't apply to externally-managed
-      returns (e.g. customer notifications, Shopify refund sync).
+    - **No customer flow.** Returns are created ready for warehouse intake —
+      no customer portal, no label generation, and no payment holds.
 
-    - **Immediately processed.** Returns are created with `provision: "processed"`,
-      meaning no customer portal flow, no label generation, and no payment holds.
-      The return is ready for warehouse intake on creation.
-
-
-    Designed for external systems (warehouse management, ERPs, offline POS) that
-    need to push returns into Redo without going through the customer portal flow.
-  operationId: Bulk upload external returns
+    - **External source.** Returns are tagged as externally-managed, which
+      skips flows like customer notifications and platform refund sync.
+  operationId: Import returns
   requestBody:
     content:
       application/json:
@@ -53,8 +51,8 @@ post:
       description: Error
   security:
     - Bearer: []
-  summary: Bulk Upload External Returns
+  summary: Import Returns
   tags: [Returns]
 parameters:
   - { $ref: ../param/store-id.param.yaml }
-summary: Bulk Upload External Returns
+summary: Import Returns

--- a/redo/api-schema/src/schema/bulk-returns-request.schema.yaml
+++ b/redo/api-schema/src/schema/bulk-returns-request.schema.yaml
@@ -1,14 +1,14 @@
 type: object
-description: Bulk external return creation request body.
+description: Import returns request body.
 properties:
   returns:
     type: array
     minItems: 1
     maxItems: 100
-    description: Array of external returns to create (max 100).
+    description: Array of returns to import (max 100).
     items:
       type: object
-      description: A single external return to create.
+      description: A single return to import.
       properties:
         products:
           type: array
@@ -20,9 +20,8 @@ properties:
               externalId:
                 type: string
                 description: >-
-                  Platform-specific variant/product identifier (e.g. Shopify GID
-                  like 'gid://shopify/ProductVariant/12345'). Resolved against
-                  the product catalog.
+                  Platform-specific variant/product identifier. Resolved
+                  against the Redo product catalog.
               quantity:
                 type: integer
                 minimum: 1

--- a/redo/api-schema/src/schema/bulk-returns-request.schema.yaml
+++ b/redo/api-schema/src/schema/bulk-returns-request.schema.yaml
@@ -1,0 +1,122 @@
+type: object
+description: Bulk external return creation request body.
+properties:
+  returns:
+    type: array
+    minItems: 1
+    maxItems: 100
+    description: Array of external returns to create (max 100).
+    items:
+      type: object
+      description: A single external return to create.
+      properties:
+        products:
+          type: array
+          minItems: 1
+          description: Products being returned (at least 1).
+          items:
+            type: object
+            properties:
+              externalId:
+                type: string
+                description: >-
+                  Platform-specific variant/product identifier (e.g. Shopify GID
+                  like 'gid://shopify/ProductVariant/12345'). Resolved against
+                  the product catalog.
+              quantity:
+                type: integer
+                minimum: 1
+                description: Number of units to return.
+              provider:
+                type: string
+                enum:
+                  - shopify
+                  - bigcommerce
+                  - commentsold
+                  - commerce-cloud
+                  - cin7-omni
+                  - cin7-core
+                  - amazon
+                  - ebay
+                description: Ecommerce platform the externalId belongs to.
+              sku:
+                type: string
+                description: Override SKU (uses catalog value if omitted).
+              barcode:
+                type: string
+                description: Override barcode (uses catalog value if omitted).
+              productTitle:
+                type: string
+                description: Override product title (uses catalog value if omitted).
+              variantTitle:
+                type: string
+                description: Override variant title (uses catalog value if omitted).
+              reason:
+                type: string
+                description: Return reason.
+              condition:
+                type: string
+                description: Item condition.
+            required: [externalId, quantity, provider]
+        customer:
+          type: object
+          description: Optional customer information.
+          properties:
+            firstName: { type: string }
+            lastName: { type: string }
+            email:
+              type: string
+              format: email
+        externalReferenceId:
+          type: string
+          description: >-
+            Merchant's own return/RMA ID. Stored on the return so it's
+            scannable at warehouse intake.
+        trackingNumber:
+          type: string
+          description: Carrier tracking number for the inbound return shipment.
+        carrier:
+          type: string
+          description: Carrier name for the tracking number (e.g. 'USPS', 'UPS').
+        notes:
+          type: string
+          description: Internal notes.
+        idempotencyKey:
+          type: string
+          description: Idempotency key to prevent duplicate return creation on retry.
+        currency:
+          type: string
+          description: ISO 4217 currency code (defaults to USD).
+          examples: [USD, GBP, EUR]
+        shippingAddress:
+          type: object
+          description: Customer's shipping address.
+          properties:
+            line1: { type: string, description: Street address line 1. }
+            line2: { type: string, description: Street address line 2. }
+            city: { type: string, description: City. }
+            state: { type: string, description: State or province code. }
+            postalCode: { type: string, description: Postal/ZIP code. }
+            country:
+              type: string
+              description: ISO 3166-1 alpha-2 country code.
+            name: { type: string, description: Recipient or location name. }
+            phone: { type: string, description: Phone number. }
+          required: [line1, city, country]
+        merchantAddress:
+          type: object
+          description: Merchant return destination address.
+          properties:
+            line1: { type: string, description: Street address line 1. }
+            line2: { type: string, description: Street address line 2. }
+            city: { type: string, description: City. }
+            state: { type: string, description: State or province code. }
+            postalCode: { type: string, description: Postal/ZIP code. }
+            country:
+              type: string
+              description: ISO 3166-1 alpha-2 country code.
+            name: { type: string, description: Recipient or location name. }
+            phone: { type: string, description: Phone number. }
+          required: [line1, city, country]
+      required: [products]
+required: [returns]

--- a/redo/api-schema/src/schema/bulk-returns-response.schema.yaml
+++ b/redo/api-schema/src/schema/bulk-returns-response.schema.yaml
@@ -1,0 +1,44 @@
+type: object
+description: Bulk external return creation response.
+properties:
+  totalCount:
+    type: integer
+    description: Total number of returns in the request.
+  processedCount:
+    type: integer
+    description: Number of returns successfully created.
+  errorCount:
+    type: integer
+    description: Number of returns that failed.
+  results:
+    type: array
+    description: Per-item results in the same order as the request.
+    items:
+      oneOf:
+        - type: object
+          properties:
+            status:
+              type: string
+              enum: [created]
+            index:
+              type: integer
+              description: Zero-based index into the request array.
+            returnId:
+              type: string
+              description: ID of the created return.
+          required: [status, index, returnId]
+        - type: object
+          properties:
+            status:
+              type: string
+              enum: [error]
+            index:
+              type: integer
+              description: Zero-based index into the request array.
+            error:
+              type: string
+              description: Error message.
+          required: [status, index, error]
+      discriminator:
+        propertyName: status
+required: [totalCount, processedCount, errorCount, results]


### PR DESCRIPTION
## Summary
- Adds OpenAPI documentation for `POST /stores/{storeId}/returns/bulk` — the Import Returns endpoint
- Clearly positioned as the way to import externally-created returns (from ERPs, warehouse systems, POS) vs the existing Create Return endpoint which operates on orders
- Full request/response schemas covering product resolution by external ID, customer info, addresses, currency, and tracking

## Companion PR
- redoapp/redo#39420 (implementation)

## Test plan
- [x] Previewed locally via `bazel run docs`
- [ ] Verify endpoint renders correctly in Mintlify
- [ ] Confirm request/response schemas display properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)