### PR TITLE
docs: add inventory items endpoints to API spec

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -44,6 +44,7 @@ tags:
   - name: Customer Subscriptions
   - name: Customers
   - name: Inbound Shipments
+  - name: Inventory Items
   - name: Inventory Levels
   - name: Invoices
   - name: Merchant Admin
@@ -746,6 +747,85 @@ paths:
       - $ref: '#/components/parameters/store-id.param'
       - $ref: '#/components/parameters/inbound-shipment-id.param'
     summary: Inbound Shipment
+  /stores/{storeId}/inventory-items:
+    description: In-stock inventory items for a store.
+    get:
+      description: List in-stock inventory items. Only items with on-hand quantity greater than zero are returned. Sorted by most recently updated first.
+      operationId: Inventory items list
+      parameters:
+        - $ref: '#/components/parameters/page-continue.param'
+        - $ref: '#/components/parameters/page-size.param'
+        - $ref: '#/components/parameters/location-id.param'
+        - $ref: '#/components/parameters/inventory-item-kind.param'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  inventory_items:
+                    items:
+                      $ref: '#/components/schemas/inventory-item-list.schema'
+                    type: array
+                required:
+                  - inventory_items
+                type: object
+          description: Success
+          headers:
+            X-Page-Next:
+              $ref: '#/components/headers/page-next.header'
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/error.schema'
+          description: Error
+      security:
+        - Bearer: []
+      summary: List Inventory Items
+      tags:
+        - Inventory Items
+    parameters:
+      - $ref: '#/components/parameters/store-id.param'
+    summary: Inventory Items
+  /stores/{storeId}/inventory-items/{inventoryItemId}:
+    description: Single inventory item.
+    get:
+      description: Get a single in-stock inventory item by ID.
+      operationId: Inventory item get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  inventory_item:
+                    $ref: '#/components/schemas/inventory-item-list.schema'
+                required:
+                  - inventory_item
+                type: object
+          description: Success
+        '404':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/error.schema'
+          description: Inventory item not found
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/error.schema'
+          description: Error
+      security:
+        - Bearer: []
+      summary: Get Inventory Item
+      tags:
+        - Inventory Items
+    parameters:
+      - $ref: '#/components/parameters/store-id.param'
+      - $ref: '#/components/parameters/inventory-item-id.param'
+    summary: Inventory Item
   /stores/{storeId}/inventory-levels:
     description: Inventory levels for a store.
     get:
@@ -2140,6 +2220,26 @@ components:
       schema:
         example: inb_7a3f9c2e1b
         type: string
+    inventory-item-kind.param:
+      description: Filter by inventory item kind
+      example: PRODUCT
+      in: query
+      name: kind
+      schema:
+        enum:
+          - PRODUCT
+          - RETURN
+          - UNDECLARED
+          - UNKNOWN
+        type: string
+    inventory-item-id.param:
+      description: Inventory item ID
+      in: path
+      name: inventoryItemId
+      required: true
+      schema:
+        example: ii_5f8e1a2b3c
+        type: string
     product-id.param:
       description: Filter by product ID (e.g. `prd_...`)
       example: prd_1a2b3c4d5e
@@ -3217,6 +3317,83 @@ components:
             - missing_count
           type: object
       title: Inbound Shipment Detail
+    inventory-item-location.schema:
+      description: Per-location quantity for an inventory item.
+      properties:
+        location_id:
+          description: Prefixed location ID (`loc_...`).
+          example: loc_4d8e1a2b3c
+          type: string
+        location_name:
+          description: Location name.
+          example: East Coast Warehouse
+          type: string
+        quantity:
+          description: On-hand quantity at this location.
+          example: 120
+          type: integer
+      required:
+        - location_id
+        - location_name
+        - quantity
+      title: Inventory Item Location
+      type: object
+    inventory-item-list.schema:
+      description: Inventory item list entry.
+      properties:
+        id:
+          description: Prefixed inventory item ID (`ii_...`).
+          example: ii_5f8e1a2b3c
+          type: string
+        sku:
+          description: Stock keeping unit from the linked product.
+          example: TSH-BLK-M
+          nullable: true
+          type: string
+        name:
+          description: Product title including variant options.
+          example: Classic Cotton T-Shirt - Black / M
+          nullable: true
+          type: string
+        kind:
+          description: Inventory item kind.
+          enum:
+            - PRODUCT
+            - RETURN
+            - UNDECLARED
+            - UNKNOWN
+          example: PRODUCT
+          type: string
+        quantity:
+          description: On-hand quantity. When `location_id` is supplied as a query filter, this is the quantity at that location; otherwise it is the total across all locations.
+          example: 250
+          type: integer
+        locations:
+          description: Per-location quantities for this inventory item.
+          items:
+            $ref: '#/components/schemas/inventory-item-location.schema'
+          type: array
+        created_at:
+          description: Creation timestamp (ISO 8601).
+          example: '2025-11-01T10:00:00.000Z'
+          format: date-time
+          type: string
+        updated_at:
+          description: Last updated timestamp (ISO 8601).
+          example: '2026-03-31T18:45:00.000Z'
+          format: date-time
+          type: string
+      required:
+        - id
+        - sku
+        - name
+        - kind
+        - quantity
+        - locations
+        - created_at
+        - updated_at
+      title: Inventory Item
+      type: object
     inventory-level-product-summary.schema:
       description: Product summary in an inventory level response.
       properties:

--- a/redo/api-schema/src/openapi.yaml
+++ b/redo/api-schema/src/openapi.yaml
@@ -50,6 +50,7 @@ tags:
   - name: Customer Subscriptions
   - name: Customers
   - name: Inbound Shipments
+  - name: Inventory Items
   - name: Inventory Levels
   - name: Invoices
   - name: Merchant Admin
@@ -82,6 +83,11 @@ paths:
     { $ref: path/inbound-shipments.path.yaml }
   /stores/{storeId}/inbound-shipments/{inboundShipmentId}:
     { $ref: path/inbound-shipment.path.yaml }
+  # Inventory Items
+  /stores/{storeId}/inventory-items:
+    { $ref: path/inventory-items.path.yaml }
+  /stores/{storeId}/inventory-items/{inventoryItemId}:
+    { $ref: path/inventory-item.path.yaml }
   # Inventory Levels
   /stores/{storeId}/inventory-levels:
     { $ref: path/inventory-levels.path.yaml }

--- a/redo/api-schema/src/param/inventory-item-id.param.yaml
+++ b/redo/api-schema/src/param/inventory-item-id.param.yaml
@@ -1,0 +1,7 @@
+description: Inventory item ID
+in: path
+name: inventoryItemId
+required: true
+schema:
+  example: ii_5f8e1a2b3c
+  type: string

--- a/redo/api-schema/src/param/inventory-item-kind.param.yaml
+++ b/redo/api-schema/src/param/inventory-item-kind.param.yaml
@@ -1,0 +1,11 @@
+description: Filter by inventory item kind
+example: PRODUCT
+in: query
+name: kind
+schema:
+  enum:
+    - PRODUCT
+    - RETURN
+    - UNDECLARED
+    - UNKNOWN
+  type: string

--- a/redo/api-schema/src/path/inventory-item.path.yaml
+++ b/redo/api-schema/src/path/inventory-item.path.yaml
@@ -1,0 +1,33 @@
+description: Single inventory item.
+get:
+  description: Get a single in-stock inventory item by ID.
+  operationId: Inventory item get
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            properties:
+              inventory_item:
+                $ref: ../schema/inventory-item-list.schema.yaml
+            required: [inventory_item]
+            type: object
+      description: Success
+    "404":
+      content:
+        application/problem+json:
+          schema: { $ref: ../schema/error.schema.yaml }
+      description: Inventory item not found
+    default:
+      content:
+        application/problem+json:
+          schema: { $ref: ../schema/error.schema.yaml }
+      description: Error
+  security:
+    - Bearer: []
+  summary: Get Inventory Item
+  tags: [Inventory Items]
+parameters:
+  - { $ref: ../param/store-id.param.yaml }
+  - { $ref: ../param/inventory-item-id.param.yaml }
+summary: Inventory Item

--- a/redo/api-schema/src/path/inventory-items.path.yaml
+++ b/redo/api-schema/src/path/inventory-items.path.yaml
@@ -1,0 +1,37 @@
+description: In-stock inventory items for a store.
+get:
+  description: >-
+    List in-stock inventory items. Only items with on-hand quantity greater
+    than zero are returned. Sorted by most recently updated first.
+  operationId: Inventory items list
+  parameters:
+    - { $ref: ../param/page-continue.param.yaml }
+    - { $ref: ../param/page-size.param.yaml }
+    - { $ref: ../param/location-id.param.yaml }
+    - { $ref: ../param/inventory-item-kind.param.yaml }
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            properties:
+              inventory_items:
+                items: { $ref: ../schema/inventory-item-list.schema.yaml }
+                type: array
+            required: [inventory_items]
+            type: object
+      description: Success
+      headers:
+        X-Page-Next: { $ref: ../header/page-next.header.yaml }
+    default:
+      content:
+        application/problem+json:
+          schema: { $ref: ../schema/error.schema.yaml }
+      description: Error
+  security:
+    - Bearer: []
+  summary: List Inventory Items
+  tags: [Inventory Items]
+parameters:
+  - { $ref: ../param/store-id.param.yaml }
+summary: Inventory Items

--- a/redo/api-schema/src/schema/inventory-item-list.schema.yaml
+++ b/redo/api-schema/src/schema/inventory-item-list.schema.yaml
@@ -1,0 +1,57 @@
+description: Inventory item list entry.
+properties:
+  id:
+    description: Prefixed inventory item ID (`ii_...`).
+    example: ii_5f8e1a2b3c
+    type: string
+  sku:
+    description: Stock keeping unit from the linked product.
+    example: TSH-BLK-M
+    nullable: true
+    type: string
+  name:
+    description: Product title including variant options.
+    example: Classic Cotton T-Shirt - Black / M
+    nullable: true
+    type: string
+  kind:
+    description: Inventory item kind.
+    enum:
+      - PRODUCT
+      - RETURN
+      - UNDECLARED
+      - UNKNOWN
+    example: PRODUCT
+    type: string
+  quantity:
+    description: >-
+      On-hand quantity. When `location_id` is supplied as a query filter, this
+      is the quantity at that location; otherwise it is the total across all
+      locations.
+    example: 250
+    type: integer
+  locations:
+    description: Per-location quantities for this inventory item.
+    items: { $ref: inventory-item-location.schema.yaml }
+    type: array
+  created_at:
+    description: Creation timestamp (ISO 8601).
+    example: "2025-11-01T10:00:00.000Z"
+    format: date-time
+    type: string
+  updated_at:
+    description: Last updated timestamp (ISO 8601).
+    example: "2026-03-31T18:45:00.000Z"
+    format: date-time
+    type: string
+required:
+  - id
+  - sku
+  - name
+  - kind
+  - quantity
+  - locations
+  - created_at
+  - updated_at
+title: Inventory Item
+type: object

--- a/redo/api-schema/src/schema/inventory-item-location.schema.yaml
+++ b/redo/api-schema/src/schema/inventory-item-location.schema.yaml
@@ -1,0 +1,17 @@
+description: Per-location quantity for an inventory item.
+properties:
+  location_id:
+    description: Prefixed location ID (`loc_...`).
+    example: loc_4d8e1a2b3c
+    type: string
+  location_name:
+    description: Location name.
+    example: East Coast Warehouse
+    type: string
+  quantity:
+    description: On-hand quantity at this location.
+    example: 120
+    type: integer
+required: [location_id, location_name, quantity]
+title: Inventory Item Location
+type: object


### PR DESCRIPTION
## Summary

Adds OpenAPI spec for the new public API endpoints introduced in redoapp/redo#39880:

- `GET /stores/{storeId}/inventory-items`
- `GET /stores/{storeId}/inventory-items/{inventoryItemId}`

## Changes

- New path files: `inventory-items.path.yaml` (list), `inventory-item.path.yaml` (detail)
- New schema files: `inventory-item-list.schema.yaml`, `inventory-item-location.schema.yaml`
- New param files: `inventory-item-id.param.yaml`, `inventory-item-kind.param.yaml` (enum: `PRODUCT` / `RETURN` / `UNDECLARED` / `UNKNOWN`)
- Registered new "Inventory Items" tag and both paths in `src/openapi.yaml`
- Regenerated `redo/api-schema/openapi.yaml` via `bazel run openapi_gen`

## Notes

The response shape matches what the handler actually returns (`id`, `sku`, `name`, `kind`, `quantity`, `locations[]`, `created_at`, `updated_at`). The PR description mentioned `storage_location_id` / `storage_location_name`, but those fields are not in the implemented handler — spec follows the code.

## Checks

- `bazel run openapi_gen` — regenerates successfully
- `bazel run docs -- openapi-check api-schema/openapi.yaml` — OpenAPI definition is valid
- `bazel run //tools/lint:prettier_lint` — clean
- `bazel run //tools/lint:yaml_lint` — clean
- `bazel run docs` — Mintlify preview renders the new endpoints under the Inventory Items tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)