### PR TITLE
docs: switch Import Returns products to Redo productId

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -1666,7 +1666,7 @@ paths:
       description: |-
         Import externally-created returns into Redo. Use this endpoint when the return originates outside of Redo — a warehouse scan, an ERP, a POS system, or a partner platform.
 
-        Products are referenced by their platform-specific external ID and resolved against the Redo product catalog. No order is required. Returns are created ready for warehouse intake. Supports up to 100 returns per request with per-item error reporting.
+        Products are referenced by their Redo product ID, obtained from the bulk product upload response. No order is required. Returns are created ready for warehouse intake. Supports up to 100 returns per request with per-item error reporting.
       operationId: Import returns
       requestBody:
         content:
@@ -5333,25 +5333,13 @@ components:
                 items:
                   type: object
                   properties:
-                    externalId:
+                    productId:
                       type: string
-                      description: Platform-specific variant/product identifier. Resolved against the Redo product catalog.
+                      description: Redo product ID returned from the bulk product upload response (e.g. `prd_ABC123`).
                     quantity:
                       type: integer
                       minimum: 1
                       description: Number of units to return.
-                    provider:
-                      type: string
-                      enum:
-                        - shopify
-                        - bigcommerce
-                        - commentsold
-                        - commerce-cloud
-                        - cin7-omni
-                        - cin7-core
-                        - amazon
-                        - ebay
-                      description: Ecommerce platform the externalId belongs to.
                     sku:
                       type: string
                       description: Override SKU (uses catalog value if omitted).
@@ -5371,9 +5359,8 @@ components:
                       type: string
                       description: Item condition.
                   required:
-                    - externalId
+                    - productId
                     - quantity
-                    - provider
               customer:
                 type: object
                 description: Optional customer information.

--- a/redo/api-schema/src/path/returns-bulk.path.yaml
+++ b/redo/api-schema/src/path/returns-bulk.path.yaml
@@ -6,10 +6,10 @@ post:
     POS system, or a partner platform.
 
 
-    Products are referenced by their platform-specific external ID and
-    resolved against the Redo product catalog. No order is required.
-    Returns are created ready for warehouse intake. Supports up to 100
-    returns per request with per-item error reporting.
+    Products are referenced by their Redo product ID, obtained from the
+    bulk product upload response. No order is required. Returns are
+    created ready for warehouse intake. Supports up to 100 returns per
+    request with per-item error reporting.
   operationId: Import returns
   requestBody:
     content:

--- a/redo/api-schema/src/schema/bulk-returns-request.schema.yaml
+++ b/redo/api-schema/src/schema/bulk-returns-request.schema.yaml
@@ -17,27 +17,15 @@ properties:
           items:
             type: object
             properties:
-              externalId:
+              productId:
                 type: string
                 description: >-
-                  Platform-specific variant/product identifier. Resolved
-                  against the Redo product catalog.
+                  Redo product ID returned from the bulk product upload
+                  response (e.g. `prd_ABC123`).
               quantity:
                 type: integer
                 minimum: 1
                 description: Number of units to return.
-              provider:
-                type: string
-                enum:
-                  - shopify
-                  - bigcommerce
-                  - commentsold
-                  - commerce-cloud
-                  - cin7-omni
-                  - cin7-core
-                  - amazon
-                  - ebay
-                description: Ecommerce platform the externalId belongs to.
               sku:
                 type: string
                 description: Override SKU (uses catalog value if omitted).
@@ -56,7 +44,7 @@ properties:
               condition:
                 type: string
                 description: Item condition.
-            required: [externalId, quantity, provider]
+            required: [productId, quantity]
         customer:
           type: object
           description: Optional customer information.


### PR DESCRIPTION
## Summary

- Replace `externalId` + `provider` fields on the Import Returns bulk request with a single `productId` field. Merchants now reference products by the Redo product ID returned from the bulk product upload response.
- Drop the provider enum (shopify, bigcommerce, amazon, etc.) — it was only used to scope the external ID lookup, which is no longer needed.
- Update the Import Returns endpoint description to reflect the new reference model, and regenerate `openapi.yaml`.

Paired with the server-side change in redo that rewrites the resolver to look products up by Redo product ID directly.

## Test plan

- [ ] Verify `bazel run openapi_gen` produces no further diff.
- [ ] Mintlify preview of the Import Returns endpoint shows `productId` as the only required product identifier.
- [ ] Bulk product upload response docs still return `id` that matches the `productId` accepted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)