### PR TITLE
Docs: widen webhook topic enum to match server

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -5899,9 +5899,12 @@ components:
       title: Webhook kind
       type: string
     webhook-topic.schema:
-      description: Webhook topic.
+      description: Webhook topic. Subscribe to `return` for return lifecycle events, `label` for outbound label purchases, `shipment` for fulfillment shipment events, or `consolidation_shipment` for consolidated shipment events.
       enum:
         - return
+        - label
+        - shipment
+        - consolidation_shipment
       title: Webhook topic
       type: string
     webhook-read.schema:

--- a/redo/api-schema/src/schema/webhook-topic.schema.yaml
+++ b/redo/api-schema/src/schema/webhook-topic.schema.yaml
@@ -1,5 +1,8 @@
 # $schema: https://json-schema.org/draft/2020-12/schema#
-description: Webhook topic.
-enum: [return]
+description: >-
+  Webhook topic. Subscribe to `return` for return lifecycle events, `label`
+  for outbound label purchases, `shipment` for fulfillment shipment events,
+  or `consolidation_shipment` for consolidated shipment events.
+enum: [return, label, shipment, consolidation_shipment]
 title: Webhook topic
 type: string


### PR DESCRIPTION
## Summary
The server-side TeamWebhook mongoose schema accepts four webhook topics:
- \`return\`
- \`label\`
- \`shipment\`
- \`consolidation_shipment\`

But the public OpenAPI doc (\`webhook-topic.schema.yaml\`) only listed \`return\`. The result: a \`POST /webhooks\` request with \`topic: \"shipment\"\` gets rejected by the OpenAPI request validator with \`com.getredo.api:enum.openapi.requestValidation\` before it ever reaches the handler.

This PR adds the three missing values so callers can subscribe to fulfillment events. No server change needed — the underlying handler already accepts them.

## Why now
PBC needs \`shipment\` topic subscriptions to receive fulfillment events from Redo Outlet (3PL) — caught while running their integration smoke test.

## Changes
- \`src/schema/webhook-topic.schema.yaml\` — enum widened to \`[return, label, shipment, consolidation_shipment]\`; description updated
- \`openapi.yaml\` — regenerated

## Test plan
- [x] \`bazel run openapi_gen\` regenerates cleanly
- [x] \`bazel run docs -- openapi-check api-schema/openapi.yaml\` validates
- [ ] Smoke: PBC re-runs \`POST /webhooks\` with \`topic: \"shipment\"\` and gets 201 instead of the validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)