### PR TITLE
RET2-1543: document productValueNoTaxNoAdjustment on return items

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -5125,16 +5125,6 @@ components:
                 required:
                   - amount
                 type: object
-              productValueNoTaxNoAdjustment:
-                description: Per-product value before taxes and merchant adjustments. Equivalent to the "Product Value (No Tax/Adjustment)" column in the Returns Report.
-                properties:
-                  amount:
-                    $ref: '#/components/schemas/money.schema'
-                    title: Amount
-                required:
-                  - amount
-                title: Product value (no tax / no adjustment)
-                type: object
               sku:
                 description: Product SKU
                 type: string

--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -5125,6 +5125,16 @@ components:
                 required:
                   - amount
                 type: object
+              productValueNoTaxNoAdjustment:
+                description: Per-product value before taxes and merchant adjustments. Equivalent to the "Product Value (No Tax/Adjustment)" column in the Returns Report.
+                properties:
+                  amount:
+                    $ref: '#/components/schemas/money.schema'
+                    title: Amount
+                required:
+                  - amount
+                title: Product value (no tax / no adjustment)
+                type: object
               sku:
                 description: Product SKU
                 type: string

--- a/redo/api-schema/src/schema/return-read.schema.yaml
+++ b/redo/api-schema/src/schema/return-read.schema.yaml
@@ -342,6 +342,18 @@ properties:
               type: string
           required: [amount]
           type: object
+        productValueNoTaxNoAdjustment:
+          description:
+            Per-product value before taxes and merchant adjustments. Equivalent
+            to the "Product Value (No Tax/Adjustment)" column in the Returns
+            Report.
+          properties:
+            amount:
+              $ref: ./money.schema.yaml
+              title: Amount
+          required: [amount]
+          title: Product value (no tax / no adjustment)
+          type: object
         sku:
           description: Product SKU
           type: string


### PR DESCRIPTION
## Summary
- Documents a new per-item `productValueNoTaxNoAdjustment: { amount: money }` field on the `return-read.schema` items array, returned by `GET /returns/{returnId}`.
- This is the per-product value before taxes and merchant adjustments — the same value shown in the merchant Return Reports column "Product Value (No Tax/Adjustment)".

Pairs with the API-side implementation in [redoapp/redo#42114](https://github.com/redoapp/redo/pull/42114).

Linear: [RET2-1543](https://linear.app/redo/issue/RET2-1543)

## Test plan
- [ ] Mintlify preview renders the new field under the Return get response schema.
- [ ] Field appears in the generated SDKs / docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)