### PR TITLE
Update docs for merchantName and UPC added to webhooks

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -2115,6 +2115,10 @@ webhooks:
                   format: date-time
                   title: At
                   type: string
+                merchantName:
+                  description: Name of the merchant team that owns this return.
+                  title: Merchant Name
+                  type: string
                 order:
                   $ref: '#/components/schemas/order-read.schema'
                   description: Order for return.
@@ -5138,6 +5142,11 @@ components:
               sku:
                 description: Product SKU
                 type: string
+              upc:
+                description: Universal Product Code (barcode) snapshotted from the product at return-creation time. Null if no barcode was recorded.
+                title: UPC
+                type: string
+                nullable: true
               status:
                 description: Return item status
                 type: string

--- a/redo/api-schema/src/schema/return-read.schema.yaml
+++ b/redo/api-schema/src/schema/return-read.schema.yaml
@@ -357,6 +357,11 @@ properties:
         sku:
           description: Product SKU
           type: string
+        upc:
+          description: Universal Product Code (barcode) snapshotted from the product at return-creation time. Null if no barcode was recorded.
+          title: UPC
+          type: string
+          nullable: true
         status:
           description: Return item status
           type: string

--- a/redo/api-schema/src/webhook/return.path.yaml
+++ b/redo/api-schema/src/webhook/return.path.yaml
@@ -11,6 +11,10 @@ post:
               format: date-time
               title: At
               type: string
+            merchantName:
+              description: Name of the merchant team that owns this return.
+              title: Merchant Name
+              type: string
             order:
               $ref: ../schema/order-read.schema.yaml
               description: Order for return.

--- a/redo/docs/guides/integrations/webhooks.mdx
+++ b/redo/docs/guides/integrations/webhooks.mdx
@@ -92,6 +92,7 @@ Return events notify you when returns are created or updated in your store.
 {
   "type": "created",
   "at": "2023-08-18T12:00:00Z",
+  "merchantName": "Example Merchant",
   "return": {
     "id": "64df65d4c5a4ca3eff4b4e43",
     "status": "pending",
@@ -107,7 +108,8 @@ Return events notify you when returns are created or updated in your store.
           "id": "order-123/1"
         },
         "quantity": 1,
-        "reason": "Too big"
+        "reason": "Too big",
+        "upc": "012345678905"
       }
     ],
     "source": {
@@ -184,8 +186,16 @@ Return events notify you when returns are created or updated in your store.
   ISO 8601 timestamp of when the event occurred
 </ResponseField>
 
+<ResponseField name="merchantName" type="string">
+  The name of the merchant team that owns this return. Useful for 3PL and integration consumers that process webhooks across multiple merchants.
+</ResponseField>
+
 <ResponseField name="return" type="object">
   Complete return object. See the Returns API reference for full schema.
+</ResponseField>
+
+<ResponseField name="return.items[].upc" type="string">
+  Universal Product Code (barcode) for the returned item, snapshotted from the product at return-creation time. `null` if no barcode was recorded for the item.
 </ResponseField>
 
 <ResponseField name="order" type="object">


### PR DESCRIPTION
## Summary

- Documents new top-level `merchantName` field (from `team.name`) in the return webhook payload
- Documents new `items[].upc` field (from `product.barcode`, `null` if not recorded) on return items
- Updates OpenAPI schema source files and regenerates `openapi.yaml`

- [x] Verified it in the UI

For this PR https://github.com/redoapp/redo/pull/42320#issue-4386519777