### PR TITLE
Orders API minor pricing field adjustments

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -3603,7 +3603,7 @@ components:
           type:
             - string
             - 'null'
-        totalDiscount:
+        discount:
           description: Total discount amount applied to this line item.
           minimum: 0
           type:
@@ -3700,6 +3700,40 @@ components:
         address:
           $ref: '#/components/schemas/orders-api-shipping-address.schema'
       type: object
+    orders-api-billing-address.schema:
+      description: Billing address.
+      properties:
+        address1:
+          description: Primary address line.
+          type:
+            - string
+            - 'null'
+        address2:
+          description: Secondary address line.
+          type:
+            - string
+            - 'null'
+        city:
+          description: City.
+          type:
+            - string
+            - 'null'
+        province:
+          description: State or province.
+          type:
+            - string
+            - 'null'
+        country:
+          description: Country.
+          type:
+            - string
+            - 'null'
+        postalCode:
+          description: Postal or zip code.
+          type:
+            - string
+            - 'null'
+      type: object
     orders-api-create-order-request.schema:
       description: Request body for creating an order.
       properties:
@@ -3738,6 +3772,14 @@ components:
           type:
             - number
             - 'null'
+        totalDiscount:
+          description: Total discount amount applied to the order (e.g. coupon codes, promotions).
+          minimum: 0
+          type:
+            - number
+            - 'null'
+        billingAddress:
+          $ref: '#/components/schemas/orders-api-billing-address.schema'
         tags:
           description: Optional tags associated with the order.
           items:

--- a/redo/api-schema/src/schema/orders-api-billing-address.schema.yaml
+++ b/redo/api-schema/src/schema/orders-api-billing-address.schema.yaml
@@ -1,0 +1,33 @@
+description: Billing address.
+properties:
+  address1:
+    description: Primary address line.
+    type:
+      - string
+      - "null"
+  address2:
+    description: Secondary address line.
+    type:
+      - string
+      - "null"
+  city:
+    description: City.
+    type:
+      - string
+      - "null"
+  province:
+    description: State or province.
+    type:
+      - string
+      - "null"
+  country:
+    description: Country.
+    type:
+      - string
+      - "null"
+  postalCode:
+    description: Postal or zip code.
+    type:
+      - string
+      - "null"
+type: object

--- a/redo/api-schema/src/schema/orders-api-create-order-request.schema.yaml
+++ b/redo/api-schema/src/schema/orders-api-create-order-request.schema.yaml
@@ -35,6 +35,14 @@ properties:
     type:
       - number
       - "null"
+  totalDiscount:
+    description: Total discount amount applied to the order (e.g. coupon codes, promotions).
+    minimum: 0
+    type:
+      - number
+      - "null"
+  billingAddress:
+    $ref: ./orders-api-billing-address.schema.yaml
   tags:
     description: Optional tags associated with the order.
     items:

--- a/redo/api-schema/src/schema/orders-api-line-item.schema.yaml
+++ b/redo/api-schema/src/schema/orders-api-line-item.schema.yaml
@@ -36,7 +36,7 @@ properties:
     type:
       - string
       - "null"
-  totalDiscount:
+  discount:
     description: Total discount amount applied to this line item.
     minimum: 0
     type:


### PR DESCRIPTION
Got more info from Porsche about needs, pretty confident this change gets us what they need.

`billingAddress`
`totalDiscount`
`lineItem.totalDiscount` -> `lineItem.discount` (no one is using this, safe to break backwards compatibility)