### PR TITLE
docs(orders-api): document line item id hyphen constraint

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -3568,7 +3568,8 @@ components:
       description: Line item in the order.
       properties:
         id:
-          description: Unique identifier for the line item.
+          description: Unique identifier for the line item. Must not contain the `-` character — Redo uses `-` as a delimiter when encoding line item ids into internal returns-accounting keys, and an id containing `-` will cause draft return creation to fail with a `LineItemNotFoundError`. Use alphanumeric ids (e.g. `LI001`, `12345`).
+          pattern: ^[^-]+$
           type: string
         productId:
           description: Identifier for the product.

--- a/redo/api-schema/src/schema/orders-api-line-item.schema.yaml
+++ b/redo/api-schema/src/schema/orders-api-line-item.schema.yaml
@@ -1,7 +1,14 @@
 description: Line item in the order.
 properties:
   id:
-    description: Unique identifier for the line item.
+    description: >-
+      Unique identifier for the line item. Must not contain the `-`
+      character — Redo uses `-` as a delimiter when encoding line item
+      ids into internal returns-accounting keys, and an id containing
+      `-` will cause draft return creation to fail with a
+      `LineItemNotFoundError`. Use alphanumeric ids (e.g. `LI001`,
+      `12345`).
+    pattern: "^[^-]+$"
     type: string
   productId:
     description: Identifier for the product.


### PR DESCRIPTION
## Summary

Redo's returns-accounting encodes line item ids into composite keys of the form \`\${orderId}-\${lineItemId}-\${unitIndex}\` and parses them by splitting on \`-\`. A line item id containing \`-\` (e.g. \`LI-API-001\`) causes the parser to mis-extract the id (it grabs just \`LI\`) and the customer-portal draft return creation flow fails with:

\`\`\`
LineItemNotFoundError: Line item LI not found in order <orderId>
\`\`\`

Real Shopify line item ids are numeric so this never trips for synced orders, but the public Orders API allows arbitrary strings.

This PR adds a \`pattern\` constraint and clarifies the field description so API consumers know to use ids without \`-\` (e.g. \`LI001\`, \`12345\`).

Schema-side rejection ships in [redoapp/redo#43659](https://github.com/redoapp/redo/pull/43659). This change keeps the published docs in sync. A longer-term fix to the returns-accounting key encoding is worth doing as a follow-up so the constraint can be relaxed.

## Test plan

- [x] \`bazel run openapi_gen\` regenerates \`openapi.yaml\` cleanly.
- [x] \`bazel run docs -- openapi-check api-schema/openapi.yaml\` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)