### PR TITLE
Remove (Beta) label from Bulk upload products endpoint

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -1388,7 +1388,7 @@ paths:
           description: Error
       security:
         - Bearer: []
-      summary: Bulk upload products (Beta)
+      summary: Bulk upload products
       tags:
         - Products
   /returns/{returnId}:

--- a/redo/api-schema/src/path/products-bulk-upload.path.yaml
+++ b/redo/api-schema/src/path/products-bulk-upload.path.yaml
@@ -133,6 +133,6 @@ post:
       description: Error
   security:
     - Bearer: []
-  summary: Bulk upload products (Beta)
+  summary: Bulk upload products
   tags:
     - Products


### PR DESCRIPTION
Removes the `(Beta)` suffix from the Bulk upload products endpoint summary so Mintlify generates the slug `/api-reference/products/bulk-upload-products` instead of `…-beta`.

## Changes
- `redo/api-schema/src/path/products-bulk-upload.path.yaml`: `Bulk upload products (Beta)` → `Bulk upload products`.
- `redo/api-schema/openapi.yaml`: regenerated via `bazel run openapi_gen`.

## Notes
- Mintlify auto-derives the URL slug from the OpenAPI `summary`, so no `docs.json` edit was needed.
- `redo/docs.json` has no `redirects` section. If a redirect from the old `/api-reference/products/bulk-upload-products-beta` URL is needed for external links, one would have to be added under a new top-level `redirects` key.
- No `x-beta` flags were attached to this endpoint; the `(Beta)` summary suffix was the only label.