### PR TITLE
Add return item grade and outcome to public API docs

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -2141,6 +2141,8 @@ webhooks:
                     upc: '012345678905'
                     quantity: 1
                     status: open
+                    grade: A
+                    outcome: restock
                     greenReturn: false
                     reason: Too big
                     reasonCode: size_too_large
@@ -5180,9 +5182,19 @@ components:
                     type: object
                 title: Exchange item
                 type: object
+              grade:
+                description: Merchant-assigned grade for the returned item (e.g. condition or quality tier). Null if the merchant has not graded this item.
+                title: Grade
+                type: string
+                nullable: true
               greenReturn:
                 description: Whether this is a green return (no physical return required)
                 type: boolean
+              outcome:
+                description: Merchant-assigned processing outcome for the returned item (e.g. restock, dispose). Null if the merchant has not set an outcome for this item.
+                title: Outcome
+                type: string
+                nullable: true
               shipmentGroupIds:
                 description: IDs of the shipment groups this return item belongs to
                 items:

--- a/redo/api-schema/src/schema/return-read.schema.yaml
+++ b/redo/api-schema/src/schema/return-read.schema.yaml
@@ -155,10 +155,25 @@ properties:
               type: object
           title: Exchange item
           type: object
+        grade:
+          description:
+            Merchant-assigned grade for the returned item (e.g. condition or
+            quality tier). Null if the merchant has not graded this item.
+          title: Grade
+          type: string
+          nullable: true
         greenReturn:
           description:
             Whether this is a green return (no physical return required)
           type: boolean
+        outcome:
+          description:
+            Merchant-assigned processing outcome for the returned item (e.g.
+            restock, dispose). Null if the merchant has not set an outcome
+            for this item.
+          title: Outcome
+          type: string
+          nullable: true
         shipmentGroupIds:
           description: IDs of the shipment groups this return item belongs to
           items:

--- a/redo/api-schema/src/webhook/return.path.yaml
+++ b/redo/api-schema/src/webhook/return.path.yaml
@@ -37,6 +37,8 @@ post:
                 upc: "012345678905"
                 quantity: 1
                 status: open
+                grade: A
+                outcome: restock
                 greenReturn: false
                 reason: Too big
                 reasonCode: size_too_large


### PR DESCRIPTION
## Summary

Reflects [redoapp/redo#45736](https://github.com/redoapp/redo/pull/45736), which exposes merchant-assigned `grade` and `outcome` on public return item responses and the standard return event webhook.

## Changes

- `redo/api-schema/src/schema/return-read.schema.yaml`: add nullable `grade` and `outcome` properties to the return item schema. Applies to get/list/create/approve return responses and the return event webhook payload (all use this shared schema).
- `redo/api-schema/src/webhook/return.path.yaml`: extend the return event webhook example payload with `grade: A` / `outcome: restock` so the docs show the new fields.
- `redo/api-schema/openapi.yaml`: regenerated via `bazel run openapi_gen`.

## Validation

- `bazel run openapi_gen` — regenerated bundled OpenAPI.
- `bazel build redo/api-schema/openapi` — bundle builds clean.
- `bazel run //tools/lint:yaml_lint` — passed.
- `bazel run //tools/lint:prettier_lint` — passed.
- `bazel run docs -- openapi-check api-schema/openapi.yaml` — not run in this workspace (`mintlify` CLI not installed locally); covered by CI.