### PR TITLE
docs(shipmonk): warn against using the Shipmonk API store ID

### DIFF
--- a/redo/docs/integrations/returns/3pl-wms/shipmonk.mdx
+++ b/redo/docs/integrations/returns/3pl-wms/shipmonk.mdx
@@ -46,6 +46,16 @@ You'll need your ShipMonk API key for authentication. This can be found in your 
 
 <Accordion title="ShipMonk Store ID" icon="store">
 You'll need your ShipMonk Store ID. This can be found in your ShipMonk account settings alongside your API credentials.
+
+<Warning>
+**Pick the Store ID for your ecommerce Store — not the one for the `Shipmonk API` Store.** In ShipMonk's **Settings > Stores** page, every connected source shows up as its own "Store" row — e.g. `Shopify v2`, `Manual Orders`, and `Shipmonk API` will each be listed with their own Store ID. Each ShipMonk order is bound to the Store that *synced* it, so orders coming from Shopify live under the **Shopify** Store — not the one whose **Type** is `Shipmonk API`.
+
+If you configure Redo with the `Shipmonk API` Store ID, RMA creation will fail with a 404 even though the order exists in ShipMonk:
+
+> Order with `"orderKey"` `"7231742542102"` using the provided `"Store ID"` `"19497"` does not exist in your Store.
+
+In ShipMonk, go to **Settings > Stores**, find the row whose **Type** matches the platform that pushes your orders into ShipMonk (typically `Shopify v2`), and copy *its* Store ID.
+</Warning>
 </Accordion>
 
 <Accordion title="Products and Orders Synced to ShipMonk" icon="box">


### PR DESCRIPTION
## Summary

Adds a `<Warning>` to the **ShipMonk Store ID** prerequisite in the ShipMonk integration doc explaining a real merchant gotcha that just caused a customer incident:

- ShipMonk's **Settings > Stores** page lists every connected source as its own "Store" — `Shopify v2`, `Manual Orders`, `Shipmonk API`, etc. — each with a distinct Store ID.
- Orders sync under the Store of the integration that pushed them. An order from Shopify lives under the **Shopify** Store, not the `Shipmonk API` Store.
- If a merchant configures Redo with the `Shipmonk API` Store ID, RMA creation 404s with `Order ... does not exist in your Store` even though the order is in ShipMonk.

The warning calls out the right row to pick (`Shopify v2` for Shopify merchants) and includes the exact error string so support / merchants can grep for it.

## Test plan

- [ ] Mintlify preview renders the new `<Warning>` block correctly inside the `<Accordion>`
- [ ] Step path "Settings > Stores" matches what merchants currently see in ShipMonk
- [ ] No other content on the page changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)