### PR TITLE
Better customer subscriptions endpoint example

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -448,6 +448,45 @@ paths:
                 sms:
                   $ref: '#/components/schemas/customer-subscription-sms.schema'
               type: object
+            examples:
+              full_example:
+                summary: All channels and subscription types
+                value:
+                  sms:
+                    phoneNumber: '+15550000000'
+                    subscriptions:
+                      marketing:
+                        subscriptionStatus: subscribed
+                        triggerAutomations: true
+                        updatedAt: '2026-01-15T10:30:00Z'
+                      transactional:
+                        subscriptionStatus: subscribed
+                        updatedAt: '2026-01-15T10:30:00Z'
+                  email:
+                    email: jane.doe@example.com
+                    subscriptions:
+                      marketing:
+                        subscriptionStatus: subscribed
+                        triggerAutomations: true
+                        updatedAt: '2026-01-15T10:30:00Z'
+              sms_only:
+                summary: SMS marketing and transactional
+                value:
+                  sms:
+                    phoneNumber: '+15550000000'
+                    subscriptions:
+                      marketing:
+                        subscriptionStatus: subscribed
+                      transactional:
+                        subscriptionStatus: subscribed
+              email_only:
+                summary: Email marketing only
+                value:
+                  email:
+                    email: jane.doe@example.com
+                    subscriptions:
+                      marketing:
+                        subscriptionStatus: unsubscribed
         required: true
       responses:
         '200':
@@ -455,6 +494,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/customer-subscription-update-response.schema'
+              examples:
+                full_example:
+                  summary: All channels updated
+                  value:
+                    success: true
+                    message: Customer subscriptions updated successfully
+                    updatedSubscriptions:
+                      sms:
+                        marketing: true
+                        transactional: true
+                      email:
+                        marketing: true
+                sms_only:
+                  summary: SMS only updated
+                  value:
+                    success: true
+                    message: Customer subscriptions updated successfully
+                    updatedSubscriptions:
+                      sms:
+                        marketing: true
           description: Success
         '400':
           content:
@@ -2898,11 +2957,45 @@ components:
         - events
       title: Bulk Custom Event Request
       type: object
+    customer-subscription-email.schema:
+      description: Email subscription updates
+      properties:
+        email:
+          description: Email address
+          format: email
+          type: string
+        subscriptions:
+          properties:
+            marketing:
+              description: Email marketing subscription. Email is always auto-confirmed on subscribe.
+              properties:
+                subscriptionStatus:
+                  description: Subscription status.
+                  enum:
+                    - subscribed
+                    - unsubscribed
+                  type: string
+                triggerAutomations:
+                  default: false
+                  description: Whether to trigger automations for this subscription change. Defaults to false.
+                  type: boolean
+                updatedAt:
+                  description: ISO 8601 timestamp. If not provided, defaults to now.
+                  format: date-time
+                  type: string
+              required:
+                - subscriptionStatus
+              type: object
+          type: object
+      required:
+        - email
+        - subscriptions
+      type: object
     subscription-status-marketing.schema:
       description: Marketing subscription status
       properties:
         subscriptionStatus:
-          description: Subscription status
+          description: Subscription status. Use `confirmed` if the customer has already completed double opt-in elsewhere and you are recording that fact.
           enum:
             - subscribed
             - confirmed
@@ -2919,22 +3012,6 @@ components:
       required:
         - subscriptionStatus
       title: Subscription Status Marketing
-      type: object
-    customer-subscription-email.schema:
-      description: Email subscription updates
-      properties:
-        email:
-          description: Email address
-          format: email
-          type: string
-        subscriptions:
-          properties:
-            marketing:
-              $ref: '#/components/schemas/subscription-status-marketing.schema'
-          type: object
-      required:
-        - email
-        - subscriptions
       type: object
     subscription-status-transactional.schema:
       description: Transactional subscription status (order tracking)

--- a/redo/api-schema/src/path/customer-subscriptions.path.yaml
+++ b/redo/api-schema/src/path/customer-subscriptions.path.yaml
@@ -19,6 +19,45 @@ post:
             sms:
               $ref: ../schema/customer-subscription-sms.schema.yaml
           type: object
+        examples:
+          full_example:
+            summary: All channels and subscription types
+            value:
+              sms:
+                phoneNumber: "+15550000000"
+                subscriptions:
+                  marketing:
+                    subscriptionStatus: subscribed
+                    triggerAutomations: true
+                    updatedAt: "2026-01-15T10:30:00Z"
+                  transactional:
+                    subscriptionStatus: subscribed
+                    updatedAt: "2026-01-15T10:30:00Z"
+              email:
+                email: "jane.doe@example.com"
+                subscriptions:
+                  marketing:
+                    subscriptionStatus: subscribed
+                    triggerAutomations: true
+                    updatedAt: "2026-01-15T10:30:00Z"
+          sms_only:
+            summary: SMS marketing and transactional
+            value:
+              sms:
+                phoneNumber: "+15550000000"
+                subscriptions:
+                  marketing:
+                    subscriptionStatus: subscribed
+                  transactional:
+                    subscriptionStatus: subscribed
+          email_only:
+            summary: Email marketing only
+            value:
+              email:
+                email: "jane.doe@example.com"
+                subscriptions:
+                  marketing:
+                    subscriptionStatus: unsubscribed
     required: true
   responses:
     "200":
@@ -26,6 +65,26 @@ post:
         application/json:
           schema:
             $ref: ../schema/customer-subscription-update-response.schema.yaml
+          examples:
+            full_example:
+              summary: All channels updated
+              value:
+                success: true
+                message: "Customer subscriptions updated successfully"
+                updatedSubscriptions:
+                  sms:
+                    marketing: true
+                    transactional: true
+                  email:
+                    marketing: true
+            sms_only:
+              summary: SMS only updated
+              value:
+                success: true
+                message: "Customer subscriptions updated successfully"
+                updatedSubscriptions:
+                  sms:
+                    marketing: true
       description: Success
     "400":
       content:

--- a/redo/api-schema/src/schema/customer-subscription-email.schema.yaml
+++ b/redo/api-schema/src/schema/customer-subscription-email.schema.yaml
@@ -7,7 +7,23 @@ properties:
   subscriptions:
     properties:
       marketing:
-        $ref: ./subscription-status-marketing.schema.yaml
+        description: Email marketing subscription. Email is always auto-confirmed on subscribe.
+        properties:
+          subscriptionStatus:
+            description: Subscription status.
+            enum: [subscribed, unsubscribed]
+            type: string
+          triggerAutomations:
+            default: false
+            description: Whether to trigger automations for this subscription change. Defaults to false.
+            type: boolean
+          updatedAt:
+            description: ISO 8601 timestamp. If not provided, defaults to now.
+            format: date-time
+            type: string
+        required:
+          - subscriptionStatus
+        type: object
     type: object
 required:
   - email

--- a/redo/api-schema/src/schema/subscription-status-marketing.schema.yaml
+++ b/redo/api-schema/src/schema/subscription-status-marketing.schema.yaml
@@ -1,7 +1,7 @@
 description: Marketing subscription status
 properties:
   subscriptionStatus:
-    description: Subscription status
+    description: Subscription status. Use `confirmed` if the customer has already completed double opt-in elsewhere and you are recording that fact.
     enum: [subscribed, confirmed, unsubscribed]
     type: string
   triggerAutomations:


### PR DESCRIPTION
The existing example was missing required fields and didn't explain the nuances of subscribe / confirm for SMS. Austin was having trouble with it