### PR TITLE
docs: add email filter query param to GET returns endpoint

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -1710,6 +1710,7 @@ paths:
         - $ref: '#/components/parameters/shopify-order-name'
         - $ref: '#/components/parameters/provider-order-name'
         - $ref: '#/components/parameters/return-status.param'
+        - $ref: '#/components/parameters/email.param'
       responses:
         '200':
           content:
@@ -2590,6 +2591,14 @@ components:
       name: status
       schema:
         $ref: '#/components/schemas/return-status.schema'
+    email.param:
+      description: Filter returns by customer email address. Applies an implicit 2-month lookback on the return creation date.
+      in: query
+      name: email
+      schema:
+        example: customer@example.com
+        format: email
+        type: string
     idempotency-key.param:
       description: Optional idempotency key for safely retrying create requests.
       in: header

--- a/redo/api-schema/src/param/email.param.yaml
+++ b/redo/api-schema/src/param/email.param.yaml
@@ -1,0 +1,9 @@
+description: >-
+  Filter returns by customer email address. Applies an implicit 2-month
+  lookback on the return creation date.
+in: query
+name: email
+schema:
+  example: customer@example.com
+  format: email
+  type: string

--- a/redo/api-schema/src/path/returns.path.yaml
+++ b/redo/api-schema/src/path/returns.path.yaml
@@ -10,6 +10,7 @@ get:
     - { $ref: ../param/shopify-order-name.yaml }
     - { $ref: ../param/provider-order-name.yaml }
     - { $ref: ../param/return-status.param.yaml }
+    - { $ref: ../param/email.param.yaml }
   responses:
     "200":
       content:


### PR DESCRIPTION
## Summary

The public API `GET /stores/{storeId}/returns` (Returns list) operation supports an `email` query filter in the server implementation, but it was absent from the published OpenAPI spec. This PR documents it.

## What changed

- Added `redo/api-schema/src/param/email.param.yaml` defining the optional `email` query parameter. The description notes the implicit 2-month lookback on the return creation date that the server applies for email filters.
- Referenced the new param from the Returns list operation in `redo/api-schema/src/path/returns.path.yaml`.
- Regenerated `redo/api-schema/openapi.yaml` via `bazel run openapi_gen`.

## Note on scope

The handoff plan listed six parameters to add, but on inspection **five of them already existed** in the OpenAPI source:

| Param | Status before this PR |
|---|---|
| `updated_at_min` | already present (`updated-at-min.param.yaml`) |
| `updated_at_max` | already present (`updated-at-max.param.yaml`) |
| `status` | already present with full enum (`return-status.param.yaml` → `return-status.schema.yaml`) |
| `shopify_order_name` | already present (`shopify-order-name.yaml`) |
| `provider_order_name` | already present (`provider-order-name.yaml`) |
| `email` | **missing — added in this PR** |

The existing `status` enum uses `pre_shipment` (underscore); I kept the repo's existing spelling as the source of truth rather than the `pre-shipment` spelling from the plan text.

## Verification

- `bazel run openapi_gen` — regenerated `openapi.yaml` cleanly; the bundle step (redocly) succeeded.
- `bazel run //tools/lint:yaml_lint` — pass.
- `bazel run //tools/lint:prettier_lint` — pass.
- `bazel run docs -- openapi-check` could not run in this workspace (`mintlify` CLI not installed); the redocly bundling in `openapi_gen` validates spec structure.