### PR TITLE
docs: add external return IDs to return schema

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -2182,7 +2182,8 @@ webhooks:
                 externalOrderIds:
                   - '1073459971'
                 externalReturnIds:
-                  - '12345'
+                  - platform: shopify
+                    value: '12345'
                 shopifyOrderIds:
                   - '1073459971'
                 compensationMethods:
@@ -5202,11 +5203,24 @@ components:
           title: External Order IDs
           type: array
         externalReturnIds:
-          description: Array of external return IDs associated with this return. For Shopify returns, these are Shopify's numeric return IDs as strings, not Shopify admin URLs or gid:// IDs.
+          description: Array of external return identifiers associated with this return. For Shopify returns, value is Shopify's numeric return ID as a string, not a Shopify admin URL or gid:// ID.
           examples:
-            - - '12345'
+            - - platform: shopify
+                value: '12345'
           items:
-            type: string
+            properties:
+              platform:
+                description: External platform that owns this return identifier
+                enum:
+                  - shopify
+                type: string
+              value:
+                description: Return identifier value from the external platform
+                type: string
+            required:
+              - platform
+              - value
+            type: object
           title: External Return IDs
           type: array
         giftCards:

--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -5207,15 +5207,12 @@ components:
           examples:
             - - provider: shopify
                 value: '12345'
-            - - provider: tiktok
-                value: '729837465'
           items:
             properties:
               provider:
                 description: External provider that owns this return identifier
                 enum:
                   - shopify
-                  - tiktok
                 type: string
               value:
                 description: Return identifier value from the external provider

--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -5199,6 +5199,12 @@ components:
             type: string
           title: External Order IDs
           type: array
+        externalReturnIds:
+          description: Array of external return IDs associated with this return
+          items:
+            type: string
+          title: External Return IDs
+          type: array
         giftCards:
           description: Gift card(s) created for return
           items:

--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -2181,6 +2181,8 @@ webhooks:
                   name: '#1234'
                 externalOrderIds:
                   - '1073459971'
+                externalReturnIds:
+                  - '12345'
                 shopifyOrderIds:
                   - '1073459971'
                 compensationMethods:
@@ -5200,7 +5202,9 @@ components:
           title: External Order IDs
           type: array
         externalReturnIds:
-          description: Array of external return IDs associated with this return
+          description: Array of external return IDs associated with this return. For Shopify returns, these are Shopify's numeric return IDs as strings, not Shopify admin URLs or gid:// IDs.
+          examples:
+            - - '12345'
           items:
             type: string
           title: External Return IDs

--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -2182,7 +2182,7 @@ webhooks:
                 externalOrderIds:
                   - '1073459971'
                 externalReturnIds:
-                  - platform: shopify
+                  - provider: shopify
                     value: '12345'
                 shopifyOrderIds:
                   - '1073459971'
@@ -5205,20 +5205,23 @@ components:
         externalReturnIds:
           description: Array of external return identifiers associated with this return. For Shopify returns, value is Shopify's numeric return ID as a string, not a Shopify admin URL or gid:// ID.
           examples:
-            - - platform: shopify
+            - - provider: shopify
                 value: '12345'
+            - - provider: tiktok
+                value: '729837465'
           items:
             properties:
-              platform:
-                description: External platform that owns this return identifier
+              provider:
+                description: External provider that owns this return identifier
                 enum:
                   - shopify
+                  - tiktok
                 type: string
               value:
-                description: Return identifier value from the external platform
+                description: Return identifier value from the external provider
                 type: string
             required:
-              - platform
+              - provider
               - value
             type: object
           title: External Return IDs

--- a/redo/api-schema/src/schema/return-read.schema.yaml
+++ b/redo/api-schema/src/schema/return-read.schema.yaml
@@ -102,12 +102,11 @@ properties:
     description: Array of external return identifiers associated with this return. For Shopify returns, value is Shopify's numeric return ID as a string, not a Shopify admin URL or gid:// ID.
     examples:
       - [{ provider: shopify, value: "12345" }]
-      - [{ provider: tiktok, value: "729837465" }]
     items:
       properties:
         provider:
           description: External provider that owns this return identifier
-          enum: [shopify, tiktok]
+          enum: [shopify]
           type: string
         value:
           description: Return identifier value from the external provider

--- a/redo/api-schema/src/schema/return-read.schema.yaml
+++ b/redo/api-schema/src/schema/return-read.schema.yaml
@@ -99,7 +99,8 @@ properties:
     title: External Order IDs
     type: array
   externalReturnIds:
-    description: Array of external return IDs associated with this return
+    description: Array of external return IDs associated with this return. For Shopify returns, these are Shopify's numeric return IDs as strings, not Shopify admin URLs or gid:// IDs.
+    examples: [["12345"]]
     items:
       type: string
     title: External Return IDs

--- a/redo/api-schema/src/schema/return-read.schema.yaml
+++ b/redo/api-schema/src/schema/return-read.schema.yaml
@@ -99,10 +99,20 @@ properties:
     title: External Order IDs
     type: array
   externalReturnIds:
-    description: Array of external return IDs associated with this return. For Shopify returns, these are Shopify's numeric return IDs as strings, not Shopify admin URLs or gid:// IDs.
-    examples: [["12345"]]
+    description: Array of external return identifiers associated with this return. For Shopify returns, value is Shopify's numeric return ID as a string, not a Shopify admin URL or gid:// ID.
+    examples:
+      - [{ platform: shopify, value: "12345" }]
     items:
-      type: string
+      properties:
+        platform:
+          description: External platform that owns this return identifier
+          enum: [shopify]
+          type: string
+        value:
+          description: Return identifier value from the external platform
+          type: string
+      required: [platform, value]
+      type: object
     title: External Return IDs
     type: array
   giftCards:

--- a/redo/api-schema/src/schema/return-read.schema.yaml
+++ b/redo/api-schema/src/schema/return-read.schema.yaml
@@ -101,17 +101,18 @@ properties:
   externalReturnIds:
     description: Array of external return identifiers associated with this return. For Shopify returns, value is Shopify's numeric return ID as a string, not a Shopify admin URL or gid:// ID.
     examples:
-      - [{ platform: shopify, value: "12345" }]
+      - [{ provider: shopify, value: "12345" }]
+      - [{ provider: tiktok, value: "729837465" }]
     items:
       properties:
-        platform:
-          description: External platform that owns this return identifier
-          enum: [shopify]
+        provider:
+          description: External provider that owns this return identifier
+          enum: [shopify, tiktok]
           type: string
         value:
-          description: Return identifier value from the external platform
+          description: Return identifier value from the external provider
           type: string
-      required: [platform, value]
+      required: [provider, value]
       type: object
     title: External Return IDs
     type: array

--- a/redo/api-schema/src/schema/return-read.schema.yaml
+++ b/redo/api-schema/src/schema/return-read.schema.yaml
@@ -98,6 +98,12 @@ properties:
       type: string
     title: External Order IDs
     type: array
+  externalReturnIds:
+    description: Array of external return IDs associated with this return
+    items:
+      type: string
+    title: External Return IDs
+    type: array
   giftCards:
     description: Gift card(s) created for return
     items:

--- a/redo/api-schema/src/webhook/return.path.yaml
+++ b/redo/api-schema/src/webhook/return.path.yaml
@@ -19,7 +19,7 @@ post:
             externalOrderIds:
               - "1073459971"
             externalReturnIds:
-              - platform: shopify
+              - provider: shopify
                 value: "12345"
             shopifyOrderIds:
               - "1073459971"

--- a/redo/api-schema/src/webhook/return.path.yaml
+++ b/redo/api-schema/src/webhook/return.path.yaml
@@ -19,7 +19,8 @@ post:
             externalOrderIds:
               - "1073459971"
             externalReturnIds:
-              - "12345"
+              - platform: shopify
+                value: "12345"
             shopifyOrderIds:
               - "1073459971"
             compensationMethods:

--- a/redo/api-schema/src/webhook/return.path.yaml
+++ b/redo/api-schema/src/webhook/return.path.yaml
@@ -18,6 +18,8 @@ post:
               name: "#1234"
             externalOrderIds:
               - "1073459971"
+            externalReturnIds:
+              - "12345"
             shopifyOrderIds:
               - "1073459971"
             compensationMethods:


### PR DESCRIPTION
## Summary
- Add `externalReturnIds` to the public return read schema.
- Regenerate the bundled OpenAPI schema so the docs reflect the new API field.

## Validation
- `bazel run openapi_gen`
- `bazel run docs -- openapi-check api-schema/openapi.yaml`