### PR TITLE
docs: ShipHero "email already in use" warning and troubleshooting

### DIFF
--- a/redo/docs/integrations/returns/3pl-wms/shiphero.mdx
+++ b/redo/docs/integrations/returns/3pl-wms/shiphero.mdx
@@ -48,6 +48,13 @@ You must have an active account with ShipHero.
   Follow [ShipHero's documentation](https://software-help.shiphero.com/hc/en-us/articles/4419362224781-How-to-Obtain-a-GraphQL-API-Access-Refresh-Token)
   to obtain a GraphQL API access refresh token. Copy this token as you'll need
   it in the next step.
+
+  <Warning>
+    Do **not** use `system@getredo.com` as the email when creating your
+    ShipHero API access token. Redo uses that address across multiple merchants,
+    so ShipHero will report it as already taken. Use any unique email address
+    instead — only the refresh token itself is passed to Redo, not the email.
+  </Warning>
 </Step>
 
 <Step title="Navigate to Integrations">
@@ -111,5 +118,21 @@ Create a test return, generate a shipping label, and verify the RMA appears in S
   arrive at the facility.
 </Step>
 </Steps>
+
+## Troubleshooting
+
+<AccordionGroup>
+<Accordion title="ShipHero says the email address is already in use" icon="triangle-exclamation">
+  When obtaining a ShipHero API access token, you may see an error stating that
+  the email address is already taken. This happens if you tried to use
+  `system@getredo.com` — Redo shares that address across multiple merchants in
+  ShipHero, so it is unavailable for new accounts.
+
+  **Fix:** Use any unique email address when creating the ShipHero API token.
+  The email is not passed to Redo — only the refresh token matters. Once you
+  have the token, enter it in the Redo integration form and complete setup as
+  normal.
+</Accordion>
+</AccordionGroup>
 
 <IntegrationSupport integrationProvider="ShipHero" />

--- a/redo/docs/integrations/returns/3pl-wms/shiphero.mdx
+++ b/redo/docs/integrations/returns/3pl-wms/shiphero.mdx
@@ -50,12 +50,10 @@ You must have an active account with ShipHero.
   it in the next step.
 
   <Warning>
-    Do **not** use `system@getredo.com` as the email when creating your
-    ShipHero API access token. Redo uses that address across multiple merchants,
-    so ShipHero will report it as already taken. Instead, use an email address
-    that will be associated with the ShipHero user account dedicated to your
-    Redo integration — only the refresh token itself is passed to Redo, not
-    the email.
+    When creating your ShipHero API access token, use an email address that is
+    unique and not already taken in ShipHero. This ensures the third-party user
+    account is created successfully. Only the refresh token itself is passed to
+    Redo, not the email.
   </Warning>
 </Step>
 
@@ -126,14 +124,12 @@ Create a test return, generate a shipping label, and verify the RMA appears in S
 <AccordionGroup>
 <Accordion title="ShipHero says the email address is already in use" icon="triangle-exclamation">
   When obtaining a ShipHero API access token, you may see an error stating that
-  the email address is already taken. This happens if you tried to use
-  `system@getredo.com` — Redo shares that address across multiple merchants in
-  ShipHero, so it is unavailable for new accounts.
+  the email address is already taken.
 
-  **Fix:** Use an email address that will be associated with the ShipHero user
-  account dedicated to your Redo integration. The email is not passed to Redo
-  — only the refresh token matters. Once you have the token, enter it in the
-  Redo integration form and complete setup as normal.
+  **Fix:** Use an email address that is unique and not already registered in
+  ShipHero. The email is not passed to Redo — only the refresh token matters.
+  Once you have the token, enter it in the Redo integration form and complete
+  setup as normal.
 </Accordion>
 </AccordionGroup>
 

--- a/redo/docs/integrations/returns/3pl-wms/shiphero.mdx
+++ b/redo/docs/integrations/returns/3pl-wms/shiphero.mdx
@@ -52,8 +52,10 @@ You must have an active account with ShipHero.
   <Warning>
     Do **not** use `system@getredo.com` as the email when creating your
     ShipHero API access token. Redo uses that address across multiple merchants,
-    so ShipHero will report it as already taken. Use any unique email address
-    instead — only the refresh token itself is passed to Redo, not the email.
+    so ShipHero will report it as already taken. Instead, use an email address
+    that will be associated with the ShipHero user account dedicated to your
+    Redo integration — only the refresh token itself is passed to Redo, not
+    the email.
   </Warning>
 </Step>
 
@@ -128,10 +130,10 @@ Create a test return, generate a shipping label, and verify the RMA appears in S
   `system@getredo.com` — Redo shares that address across multiple merchants in
   ShipHero, so it is unavailable for new accounts.
 
-  **Fix:** Use any unique email address when creating the ShipHero API token.
-  The email is not passed to Redo — only the refresh token matters. Once you
-  have the token, enter it in the Redo integration form and complete setup as
-  normal.
+  **Fix:** Use an email address that will be associated with the ShipHero user
+  account dedicated to your Redo integration. The email is not passed to Redo
+  — only the refresh token matters. Once you have the token, enter it in the
+  Redo integration form and complete setup as normal.
 </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
## Summary

When creating a ShipHero API access token, merchants can hit an "email already in use" error if they use an email that's already registered in ShipHero.

Per Seth Weeks (Slack, 2026-06-19): the email used to create the token doesn't matter — only the refresh token is passed to Redo. Merchants just need to use a unique, unregistered email.

### Changes

- **Step 1 (Obtain ShipHero Refresh Token)**: Added a `<Warning>` telling merchants to use an email that is unique and not already taken in ShipHero.
- **New Troubleshooting section**: Accordion entry for "ShipHero says the email address is already in use" with the fix.

## Files Changed

- `redo/docs/integrations/returns/3pl-wms/shiphero.mdx`