### PR TITLE
docs: document v2 API access scopes

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -213,6 +213,8 @@ paths:
 
         ## Rate Limiting
         This endpoint is rate-limited to 100 requests per second per store.
+
+        Requires the [`customer_events_write`](/docs/api-reference/scopes) scope.
       operationId: Custom event create
       x-express-openapi-disable-validation-middleware: true
       parameters:
@@ -346,6 +348,8 @@ paths:
 
         ## Rate Limiting
         This endpoint is rate-limited to 100 requests per second per store.
+
+        Requires the [`customer_events_write`](/docs/api-reference/scopes) scope.
       operationId: Bulk create custom events
       x-express-openapi-disable-validation-middleware: true
       parameters:
@@ -434,7 +438,7 @@ paths:
   /stores/{storeId}/customer-subscriptions:
     description: Update customer subscription preferences for marketing and transactional messages.
     post:
-      description: Update customer subscription status for SMS and email marketing and transactional messages. If the customer with that phone number or email does not exist, it will be created.
+      description: Update customer subscription status for SMS and email marketing and transactional messages. If the customer with that phone number or email does not exist, it will be created. Requires the [`customers_write`](/docs/api-reference/scopes) scope.
       operationId: Customer subscriptions update
       parameters:
         - $ref: '#/components/parameters/store-id.param'
@@ -548,6 +552,8 @@ paths:
         The response includes the customer's name, contact information, location,
         and any custom fields associated with the profile. Custom fields are returned
         as `{ fieldName: value }` pairs.
+
+        Requires the [`customers_read`](/docs/api-reference/scopes) scope.
       operationId: Customer get
       parameters:
         - $ref: '#/components/parameters/store-id.param'
@@ -639,6 +645,8 @@ paths:
         Use `customFields` to store arbitrary key-value data on the customer (e.g.,
         `pricing_plan`, `subscription_source`). Values can be strings, numbers, or
         booleans. If a custom field doesn't exist yet, it is created automatically.
+
+        Requires the [`customers_write`](/docs/api-reference/scopes) scope.
       operationId: Customer upsert
       parameters:
         - $ref: '#/components/parameters/store-id.param'
@@ -728,7 +736,9 @@ paths:
   /stores/{storeId}/inbound-shipments:
     description: Inbound shipments for a store.
     get:
-      description: List inbound shipments, representing inventory in transit or received at a location. Sorted by most recently updated first.
+      description: |-
+        List inbound shipments, representing inventory in transit or received at a location. Sorted by most recently updated first.
+        Requires the [`inbound_shipments_read`](/docs/api-reference/scopes) scope.
       operationId: Inbound shipments list
       parameters:
         - $ref: '#/components/parameters/page-continue.param'
@@ -771,7 +781,9 @@ paths:
   /stores/{storeId}/inbound-shipments/{inboundShipmentId}:
     description: Single inbound shipment.
     get:
-      description: Get a single inbound shipment by ID. Returns additional detail fields including purchase orders, transfer orders, files, volume, item discrepancies, and packing modes.
+      description: |-
+        Get a single inbound shipment by ID. Returns additional detail fields including purchase orders, transfer orders, files, volume, item discrepancies, and packing modes.
+        Requires the [`inbound_shipments_read`](/docs/api-reference/scopes) scope.
       operationId: Inbound shipment get
       responses:
         '200':
@@ -809,7 +821,9 @@ paths:
   /stores/{storeId}/inventory-items:
     description: In-stock inventory items for a store.
     get:
-      description: List in-stock inventory items. Only items with on-hand quantity greater than zero are returned. Sorted by most recently updated first.
+      description: |-
+        List in-stock inventory items. Only items with on-hand quantity greater than zero are returned. Sorted by most recently updated first.
+        Requires the [`inventory_read`](/docs/api-reference/scopes) scope.
       operationId: Inventory items list
       parameters:
         - $ref: '#/components/parameters/page-continue.param'
@@ -850,7 +864,7 @@ paths:
   /stores/{storeId}/inventory-items/{inventoryItemId}:
     description: Single inventory item.
     get:
-      description: Get a single in-stock inventory item by ID.
+      description: Get a single in-stock inventory item by ID. Requires the [`inventory_read`](/docs/api-reference/scopes) scope.
       operationId: Inventory item get
       responses:
         '200':
@@ -888,7 +902,9 @@ paths:
   /stores/{storeId}/inventory-levels:
     description: Inventory levels for a store.
     get:
-      description: List inventory levels, representing the aggregate quantity of a product at a specific location. Sorted by most recently updated first.
+      description: |-
+        List inventory levels, representing the aggregate quantity of a product at a specific location. Sorted by most recently updated first.
+        Requires the [`inventory_read`](/docs/api-reference/scopes) scope.
       operationId: Inventory levels list
       parameters:
         - $ref: '#/components/parameters/page-continue.param'
@@ -932,7 +948,9 @@ paths:
   /stores/{storeId}/inventory-levels/{inventoryLevelId}:
     description: Single inventory level.
     get:
-      description: Get a single inventory level by ID. Returns additional detail fields including external IDs, creation timestamp, product UPC, and image URL.
+      description: |-
+        Get a single inventory level by ID. Returns additional detail fields including external IDs, creation timestamp, product UPC, and image URL.
+        Requires the [`inventory_read`](/docs/api-reference/scopes) scope.
       operationId: Inventory level get
       responses:
         '200':
@@ -970,7 +988,7 @@ paths:
   /invoices/pending/items.csv:
     description: Return invoice CSV file.
     get:
-      description: Get an invoice as a CSV.
+      description: Get an invoice as a CSV. Requires the [`invoices_read`](/docs/api-reference/scopes) scope.
       operationId: Invoice pending csv get
       responses:
         '200':
@@ -995,7 +1013,7 @@ paths:
   /invoices/{invoiceId}/items.csv:
     description: Return invoice CSV file.
     get:
-      description: Get an invoice as a CSV.
+      description: Get an invoice as a CSV. Requires the [`invoices_read`](/docs/api-reference/scopes) scope.
       operationId: Invoice csv get
       parameters:
         - $ref: '#/components/parameters/invoice-id.param'
@@ -1022,7 +1040,7 @@ paths:
   /stores/{storeId}/invoices:
     description: Return a list of invoices.
     get:
-      description: Get a list of invoices.
+      description: Get a list of invoices. Requires the [`invoices_read`](/docs/api-reference/scopes) scope.
       operationId: Invoice list
       parameters:
         - $ref: '#/components/parameters/store-id.param'
@@ -1069,7 +1087,7 @@ paths:
   /stores/{storeId}/orders:
     description: Orders collection.
     post:
-      description: Create a new order in the system with line items, customer information, and shipping details.
+      description: Create a new order in the system with line items, customer information, and shipping details. Requires the [`orders_write`](/docs/api-reference/scopes) scope.
       operationId: Order create
       requestBody:
         content:
@@ -1119,7 +1137,7 @@ paths:
   /stores/{storeId}/orders/{orderId}:
     description: Single order operations.
     get:
-      description: Retrieve an existing order from the system, including all fulfillments. The orderId parameter can be either the external order ID you provided when creating the order, or the internal Redo order ID returned from the create order response.
+      description: Retrieve an existing order from the system, including all fulfillments. The orderId parameter can be either the external order ID you provided when creating the order, or the internal Redo order ID returned from the create order response. Requires the [`orders_read`](/docs/api-reference/scopes) scope.
       operationId: Order get
       responses:
         '200':
@@ -1152,7 +1170,7 @@ paths:
       tags:
         - Orders
     delete:
-      description: Delete an order from the system. The orderId parameter can be either the external order ID you provided when creating the order, or the internal Redo order ID returned from the create order response.
+      description: Delete an order from the system. The orderId parameter can be either the external order ID you provided when creating the order, or the internal Redo order ID returned from the create order response. Requires the [`orders_write`](/docs/api-reference/scopes) scope.
       operationId: Order delete
       responses:
         '200':
@@ -1191,7 +1209,7 @@ paths:
   /stores/{storeId}/orders/{orderId}/fulfillments:
     description: Order fulfillments collection.
     post:
-      description: Create a fulfillment for specific line items within an order, including tracking information. The orderId parameter can be either the external order ID you provided when creating the order, or the internal Redo order ID returned from the create order response.
+      description: Create a fulfillment for specific line items within an order, including tracking information. The orderId parameter can be either the external order ID you provided when creating the order, or the internal Redo order ID returned from the create order response. Requires the [`orders_write`](/docs/api-reference/scopes) scope.
       operationId: Fulfillment create
       requestBody:
         content:
@@ -1252,6 +1270,8 @@ paths:
         **Events** (e.g., `stalled_in_transit`, `delayed`, `arriving_early`): Special event types that trigger automations without changing the current shipment status. The status field remains unchanged, but you can still update estimated delivery date and add tracking history entries. Use these to trigger event-based automations.
 
         Both statuses and events can update other fields like estimated delivery date and tracking history.
+
+        Requires the [`orders_write`](/docs/api-reference/scopes) scope.
       operationId: Fulfillment status update
       requestBody:
         content:
@@ -1322,6 +1342,8 @@ paths:
 
         Only one bulk upload operation can run per store at a time. If a bulk upload is already
         in progress, the request will return a `409 Conflict` error.
+
+        Requires the [`products_write`](/docs/api-reference/scopes) scope.
       operationId: Products bulk upload
       parameters:
         - $ref: '#/components/parameters/store-id.param'
@@ -1453,7 +1475,7 @@ paths:
   /returns/{returnId}:
     description: Return.
     get:
-      description: Get return.
+      description: Get return. Requires the [`returns_read`](/docs/api-reference/scopes) scope.
       operationId: Return get
       responses:
         '200':
@@ -1487,7 +1509,7 @@ paths:
   /returns/{returnId}/comments:
     description: Return comment.
     get:
-      description: List return comments.
+      description: List return comments. Requires the [`returns_read`](/docs/api-reference/scopes) scope.
       operationId: Return comments get
       responses:
         '200':
@@ -1511,7 +1533,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/return-id.param'
     post:
-      description: Create return comment.
+      description: Create return comment. Requires the [`returns_write`](/docs/api-reference/scopes) scope.
       operationId: Return comment create
       requestBody:
         content:
@@ -1557,6 +1579,8 @@ paths:
         **BETA**: This endpoint is in beta and subject to change.
 
         Trigger processing of a return with specified products.
+
+        Requires the [`returns_write`](/docs/api-reference/scopes) scope.
       operationId: Return process
       requestBody:
         content:
@@ -1633,7 +1657,7 @@ paths:
   /returns/{returnId}/status:
     description: Return status.
     get:
-      description: Get return status.
+      description: Get return status. Requires the [`returns_read`](/docs/api-reference/scopes) scope.
       operationId: Return status get
       parameters:
         - $ref: '#/components/parameters/return-id.param'
@@ -1668,6 +1692,8 @@ paths:
 
         - Setting status to **complete** will also mark all return items as complete.
         - Setting status to **open** from **complete** or **rejected** will reopen the return, resetting all processed/rejected items back to open, clearing pending processing info, resetting the expiration date, and marking the return as reopened. **Note:** Reopening a processed return does not reverse any refunds, exchanges, or other actions that were performed during processing.
+
+        Requires the [`returns_write`](/docs/api-reference/scopes) scope.
       operationId: Return status update
       parameters:
         - $ref: '#/components/parameters/return-id.param'
@@ -1700,7 +1726,7 @@ paths:
   /stores/{storeId}/returns:
     description: List of returns for store.
     get:
-      description: List returns, sorted by most recent to least recent.
+      description: List returns, sorted by most recent to least recent. Requires the [`returns_read`](/docs/api-reference/scopes) scope.
       operationId: Returns list
       parameters:
         - $ref: '#/components/parameters/page-continue.param'
@@ -1744,7 +1770,7 @@ paths:
       tags:
         - Returns
     post:
-      description: Create a return for specific order line items.
+      description: Create a return for specific order line items. Requires the [`returns_write`](/docs/api-reference/scopes) scope.
       operationId: Return create
       parameters:
         - $ref: '#/components/parameters/idempotency-key.param'
@@ -1806,6 +1832,7 @@ paths:
         Import externally-created returns into Redo. Use this endpoint when the return originates outside of Redo — a warehouse scan, an ERP, a POS system, or a partner platform.
 
         Products are referenced by their Redo product ID, obtained from the bulk product upload response. No order is required. Returns are created ready for warehouse intake. Supports up to 100 returns per request with per-item error reporting.
+        Requires the [`returns_write`](/docs/api-reference/scopes) scope.
       operationId: Import returns
       requestBody:
         content:
@@ -1843,7 +1870,7 @@ paths:
   /stores/{storeId}/return-tags:
     description: Return tags for a store.
     get:
-      description: List every return tag defined for the store.
+      description: List every return tag defined for the store. Requires the [`returns_read`](/docs/api-reference/scopes) scope.
       operationId: Return tags list
       responses:
         '200':
@@ -1875,7 +1902,9 @@ paths:
     summary: Return Tags
   /stores/{storeId}/return-tags/{name}:
     delete:
-      description: Delete a return tag. The tag is also stripped from every return and saved view filter that referenced it.
+      description: |-
+        Delete a return tag. The tag is also stripped from every return and saved view filter that referenced it.
+        Requires the [`returns_write`](/docs/api-reference/scopes) scope.
       operationId: Return tag delete
       responses:
         '200':
@@ -1918,6 +1947,8 @@ paths:
 
         - `com.getredo.api:return-tag/invalid-request` — the path `name` is
           missing or the request body is invalid.
+
+        Requires the [`returns_write`](/docs/api-reference/scopes) scope.
       operationId: Return tag upsert
       requestBody:
         content:
@@ -1960,7 +1991,7 @@ paths:
     summary: Return Tag
   /stores/{storeId}/storefront/events:
     post:
-      description: Processes events from storefronts using Shopify pixel event schema
+      description: Processes events from storefronts using Shopify pixel event schema Requires the [`storefront_events_write`](/docs/api-reference/scopes) scope.
       operationId: Storefront Event
       parameters:
         - $ref: '#/components/parameters/store-id.param'
@@ -1993,7 +2024,7 @@ paths:
   /stores/{storeId}/webhooks:
     description: Webhooks.
     get:
-      description: List webhooks for store.
+      description: List webhooks for store. Requires the [`webhooks_read`](/docs/api-reference/scopes) scope.
       operationId: Webhooks list
       responses:
         '200':
@@ -2021,7 +2052,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/store-id.param'
     post:
-      description: Create webhook for store. Or if webhook already exists with `externalId`, update it.
+      description: Create webhook for store. Or if webhook already exists with `externalId`, update it. Requires the [`webhooks_write`](/docs/api-reference/scopes) scope.
       operationId: Webhook create
       requestBody:
         content:
@@ -2065,7 +2096,7 @@ paths:
     summary: Webhooks
   /webhooks/{webhookId}:
     delete:
-      description: Delete a webhook.
+      description: Delete a webhook. Requires the [`webhooks_write`](/docs/api-reference/scopes) scope.
       operationId: Webhook delete
       parameters:
         - $ref: '#/components/parameters/webhook-id.param'
@@ -2079,7 +2110,7 @@ paths:
         - Webhooks
     description: Webhook.
     get:
-      description: Get a webhook.
+      description: Get a webhook. Requires the [`webhooks_read`](/docs/api-reference/scopes) scope.
       operationId: Webhook get
       parameters:
         - $ref: '#/components/parameters/webhook-id.param'
@@ -2099,7 +2130,7 @@ paths:
       tags:
         - Webhooks
     put:
-      description: Update a webhook.
+      description: Update a webhook. Requires the [`webhooks_write`](/docs/api-reference/scopes) scope.
       operationId: Webhook update
       parameters:
         - $ref: '#/components/parameters/webhook-id.param'
@@ -2132,7 +2163,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/webhook-id.param'
     post:
-      description: Replay a webhook.
+      description: Replay a webhook. Requires the [`webhooks_write`](/docs/api-reference/scopes) scope.
       operationId: Webhook replay
       requestBody:
         content:

--- a/redo/api-schema/src/path/custom-events-bulk.path.yaml
+++ b/redo/api-schema/src/path/custom-events-bulk.path.yaml
@@ -18,6 +18,8 @@ post:
 
     ## Rate Limiting
     This endpoint is rate-limited to 100 requests per second per store.
+
+    Requires the [`customer_events_write`](/docs/api-reference/scopes) scope.
   operationId: Bulk create custom events
   x-express-openapi-disable-validation-middleware: true
   parameters:

--- a/redo/api-schema/src/path/custom-events.path.yaml
+++ b/redo/api-schema/src/path/custom-events.path.yaml
@@ -23,6 +23,8 @@ post:
 
     ## Rate Limiting
     This endpoint is rate-limited to 100 requests per second per store.
+
+    Requires the [`customer_events_write`](/docs/api-reference/scopes) scope.
   operationId: Custom event create
   x-express-openapi-disable-validation-middleware: true
   parameters:

--- a/redo/api-schema/src/path/customer-subscriptions.path.yaml
+++ b/redo/api-schema/src/path/customer-subscriptions.path.yaml
@@ -5,7 +5,7 @@ post:
   description:
     Update customer subscription status for SMS and email marketing and
     transactional messages. If the customer with that phone number or email does
-    not exist, it will be created.
+    not exist, it will be created. Requires the [`customers_write`](/docs/api-reference/scopes) scope.
   operationId: Customer subscriptions update
   parameters:
     - $ref: ../param/store-id.param.yaml

--- a/redo/api-schema/src/path/customers.path.yaml
+++ b/redo/api-schema/src/path/customers.path.yaml
@@ -6,6 +6,8 @@ get:
     The response includes the customer's name, contact information, location,
     and any custom fields associated with the profile. Custom fields are returned
     as `{ fieldName: value }` pairs.
+
+    Requires the [`customers_read`](/docs/api-reference/scopes) scope.
   operationId: Customer get
   parameters:
     - $ref: "../param/store-id.param.yaml"
@@ -97,6 +99,8 @@ put:
     Use `customFields` to store arbitrary key-value data on the customer (e.g.,
     `pricing_plan`, `subscription_source`). Values can be strings, numbers, or
     booleans. If a custom field doesn't exist yet, it is created automatically.
+
+    Requires the [`customers_write`](/docs/api-reference/scopes) scope.
   operationId: Customer upsert
   parameters:
     - $ref: "../param/store-id.param.yaml"

--- a/redo/api-schema/src/path/inbound-shipment.path.yaml
+++ b/redo/api-schema/src/path/inbound-shipment.path.yaml
@@ -4,6 +4,8 @@ get:
     Get a single inbound shipment by ID. Returns additional detail fields
     including purchase orders, transfer orders, files, volume, item discrepancies,
     and packing modes.
+
+    Requires the [`inbound_shipments_read`](/docs/api-reference/scopes) scope.
   operationId: Inbound shipment get
   responses:
     "200":

--- a/redo/api-schema/src/path/inbound-shipments.path.yaml
+++ b/redo/api-schema/src/path/inbound-shipments.path.yaml
@@ -3,6 +3,8 @@ get:
   description: >-
     List inbound shipments, representing inventory in transit or received at a
     location. Sorted by most recently updated first.
+
+    Requires the [`inbound_shipments_read`](/docs/api-reference/scopes) scope.
   operationId: Inbound shipments list
   parameters:
     - { $ref: ../param/page-continue.param.yaml }

--- a/redo/api-schema/src/path/inventory-item.path.yaml
+++ b/redo/api-schema/src/path/inventory-item.path.yaml
@@ -1,6 +1,6 @@
 description: Single inventory item.
 get:
-  description: Get a single in-stock inventory item by ID.
+  description: Get a single in-stock inventory item by ID. Requires the [`inventory_read`](/docs/api-reference/scopes) scope.
   operationId: Inventory item get
   responses:
     "200":

--- a/redo/api-schema/src/path/inventory-items.path.yaml
+++ b/redo/api-schema/src/path/inventory-items.path.yaml
@@ -3,6 +3,8 @@ get:
   description: >-
     List in-stock inventory items. Only items with on-hand quantity greater
     than zero are returned. Sorted by most recently updated first.
+
+    Requires the [`inventory_read`](/docs/api-reference/scopes) scope.
   operationId: Inventory items list
   parameters:
     - { $ref: ../param/page-continue.param.yaml }

--- a/redo/api-schema/src/path/inventory-level.path.yaml
+++ b/redo/api-schema/src/path/inventory-level.path.yaml
@@ -3,6 +3,8 @@ get:
   description: >-
     Get a single inventory level by ID. Returns additional detail fields
     including external IDs, creation timestamp, product UPC, and image URL.
+
+    Requires the [`inventory_read`](/docs/api-reference/scopes) scope.
   operationId: Inventory level get
   responses:
     "200":

--- a/redo/api-schema/src/path/inventory-levels.path.yaml
+++ b/redo/api-schema/src/path/inventory-levels.path.yaml
@@ -3,6 +3,8 @@ get:
   description: >-
     List inventory levels, representing the aggregate quantity of a product at a
     specific location. Sorted by most recently updated first.
+
+    Requires the [`inventory_read`](/docs/api-reference/scopes) scope.
   operationId: Inventory levels list
   parameters:
     - { $ref: ../param/page-continue.param.yaml }

--- a/redo/api-schema/src/path/invoice-csv.path.yaml
+++ b/redo/api-schema/src/path/invoice-csv.path.yaml
@@ -1,6 +1,6 @@
 description: Return invoice CSV file.
 get:
-  description: Get an invoice as a CSV.
+  description: Get an invoice as a CSV. Requires the [`invoices_read`](/docs/api-reference/scopes) scope.
   operationId: Invoice csv get
   parameters:
     - { $ref: ../param/invoice-id.param.yaml }

--- a/redo/api-schema/src/path/invoice-pending-csv.path.yaml
+++ b/redo/api-schema/src/path/invoice-pending-csv.path.yaml
@@ -1,6 +1,6 @@
 description: Return invoice CSV file.
 get:
-  description: Get an invoice as a CSV.
+  description: Get an invoice as a CSV. Requires the [`invoices_read`](/docs/api-reference/scopes) scope.
   operationId: Invoice pending csv get
   responses:
     "200":

--- a/redo/api-schema/src/path/order-fulfillment-shipment-status.path.yaml
+++ b/redo/api-schema/src/path/order-fulfillment-shipment-status.path.yaml
@@ -10,6 +10,8 @@ post:
     **Events** (e.g., `stalled_in_transit`, `delayed`, `arriving_early`): Special event types that trigger automations without changing the current shipment status. The status field remains unchanged, but you can still update estimated delivery date and add tracking history entries. Use these to trigger event-based automations.
 
     Both statuses and events can update other fields like estimated delivery date and tracking history.
+
+    Requires the [`orders_write`](/docs/api-reference/scopes) scope.
   operationId: Fulfillment status update
   requestBody:
     content:

--- a/redo/api-schema/src/path/order-fulfillments.path.yaml
+++ b/redo/api-schema/src/path/order-fulfillments.path.yaml
@@ -1,6 +1,6 @@
 description: Order fulfillments collection.
 post:
-  description: Create a fulfillment for specific line items within an order, including tracking information. The orderId parameter can be either the external order ID you provided when creating the order, or the internal Redo order ID returned from the create order response.
+  description: Create a fulfillment for specific line items within an order, including tracking information. The orderId parameter can be either the external order ID you provided when creating the order, or the internal Redo order ID returned from the create order response. Requires the [`orders_write`](/docs/api-reference/scopes) scope.
   operationId: Fulfillment create
   requestBody:
     content:

--- a/redo/api-schema/src/path/order.path.yaml
+++ b/redo/api-schema/src/path/order.path.yaml
@@ -1,6 +1,6 @@
 description: Single order operations.
 get:
-  description: Retrieve an existing order from the system, including all fulfillments. The orderId parameter can be either the external order ID you provided when creating the order, or the internal Redo order ID returned from the create order response.
+  description: Retrieve an existing order from the system, including all fulfillments. The orderId parameter can be either the external order ID you provided when creating the order, or the internal Redo order ID returned from the create order response. Requires the [`orders_read`](/docs/api-reference/scopes) scope.
   operationId: Order get
   responses:
     "200":
@@ -29,7 +29,7 @@ get:
   summary: Get Order
   tags: [Orders]
 delete:
-  description: Delete an order from the system. The orderId parameter can be either the external order ID you provided when creating the order, or the internal Redo order ID returned from the create order response.
+  description: Delete an order from the system. The orderId parameter can be either the external order ID you provided when creating the order, or the internal Redo order ID returned from the create order response. Requires the [`orders_write`](/docs/api-reference/scopes) scope.
   operationId: Order delete
   responses:
     "200":

--- a/redo/api-schema/src/path/orders.path.yaml
+++ b/redo/api-schema/src/path/orders.path.yaml
@@ -1,6 +1,6 @@
 description: Orders collection.
 post:
-  description: Create a new order in the system with line items, customer information, and shipping details.
+  description: Create a new order in the system with line items, customer information, and shipping details. Requires the [`orders_write`](/docs/api-reference/scopes) scope.
   operationId: Order create
   requestBody:
     content:

--- a/redo/api-schema/src/path/products-bulk-upload.path.yaml
+++ b/redo/api-schema/src/path/products-bulk-upload.path.yaml
@@ -19,6 +19,8 @@ post:
 
     Only one bulk upload operation can run per store at a time. If a bulk upload is already
     in progress, the request will return a `409 Conflict` error.
+
+    Requires the [`products_write`](/docs/api-reference/scopes) scope.
   operationId: Products bulk upload
   parameters:
     - $ref: "../param/store-id.param.yaml"

--- a/redo/api-schema/src/path/return-comments.path.yaml
+++ b/redo/api-schema/src/path/return-comments.path.yaml
@@ -1,6 +1,6 @@
 description: Return comment.
 get:
-  description: List return comments.
+  description: List return comments. Requires the [`returns_read`](/docs/api-reference/scopes) scope.
   operationId: Return comments get
   responses:
     "200":
@@ -21,7 +21,7 @@ get:
 parameters:
   - { $ref: ../param/return-id.param.yaml }
 post:
-  description: Create return comment.
+  description: Create return comment. Requires the [`returns_write`](/docs/api-reference/scopes) scope.
   operationId: Return comment create
   requestBody:
     content:

--- a/redo/api-schema/src/path/return-payout-object-list.path.yaml
+++ b/redo/api-schema/src/path/return-payout-object-list.path.yaml
@@ -1,6 +1,6 @@
 description: Return a list of invoices.
 get:
-  description: Get a list of invoices.
+  description: Get a list of invoices. Requires the [`invoices_read`](/docs/api-reference/scopes) scope.
   operationId: Invoice list
   parameters: [{ $ref: ../param/store-id.param.yaml }]
   responses:

--- a/redo/api-schema/src/path/return-process.path.yaml
+++ b/redo/api-schema/src/path/return-process.path.yaml
@@ -6,6 +6,8 @@ post:
     **BETA**: This endpoint is in beta and subject to change.
 
     Trigger processing of a return with specified products.
+
+    Requires the [`returns_write`](/docs/api-reference/scopes) scope.
   operationId: Return process
   requestBody:
     content:

--- a/redo/api-schema/src/path/return-status.path.yaml
+++ b/redo/api-schema/src/path/return-status.path.yaml
@@ -1,6 +1,6 @@
 description: Return status.
 get:
-  description: Get return status.
+  description: Get return status. Requires the [`returns_read`](/docs/api-reference/scopes) scope.
   operationId: Return status get
   parameters:
     - { $ref: ../param/return-id.param.yaml }
@@ -31,6 +31,8 @@ put:
 
     - Setting status to **complete** will also mark all return items as complete.
     - Setting status to **open** from **complete** or **rejected** will reopen the return, resetting all processed/rejected items back to open, clearing pending processing info, resetting the expiration date, and marking the return as reopened. **Note:** Reopening a processed return does not reverse any refunds, exchanges, or other actions that were performed during processing.
+
+    Requires the [`returns_write`](/docs/api-reference/scopes) scope.
   operationId: Return status update
   parameters:
     - { $ref: ../param/return-id.param.yaml }

--- a/redo/api-schema/src/path/return-tag.path.yaml
+++ b/redo/api-schema/src/path/return-tag.path.yaml
@@ -2,6 +2,8 @@ delete:
   description: >-
     Delete a return tag. The tag is also stripped from every return and
     saved view filter that referenced it.
+
+    Requires the [`returns_write`](/docs/api-reference/scopes) scope.
   operationId: Return tag delete
   responses:
     "200":
@@ -45,6 +47,8 @@ put:
 
     - `com.getredo.api:return-tag/invalid-request` — the path `name` is
       missing or the request body is invalid.
+
+    Requires the [`returns_write`](/docs/api-reference/scopes) scope.
   operationId: Return tag upsert
   requestBody:
     content:

--- a/redo/api-schema/src/path/return-tags.path.yaml
+++ b/redo/api-schema/src/path/return-tags.path.yaml
@@ -1,6 +1,6 @@
 description: Return tags for a store.
 get:
-  description: List every return tag defined for the store.
+  description: List every return tag defined for the store. Requires the [`returns_read`](/docs/api-reference/scopes) scope.
   operationId: Return tags list
   responses:
     "200":

--- a/redo/api-schema/src/path/return.path.yaml
+++ b/redo/api-schema/src/path/return.path.yaml
@@ -1,6 +1,6 @@
 description: Return.
 get:
-  description: Get return.
+  description: Get return. Requires the [`returns_read`](/docs/api-reference/scopes) scope.
   operationId: Return get
   responses:
     "200":

--- a/redo/api-schema/src/path/returns-bulk.path.yaml
+++ b/redo/api-schema/src/path/returns-bulk.path.yaml
@@ -10,6 +10,8 @@ post:
     bulk product upload response. No order is required. Returns are
     created ready for warehouse intake. Supports up to 100 returns per
     request with per-item error reporting.
+
+    Requires the [`returns_write`](/docs/api-reference/scopes) scope.
   operationId: Import returns
   requestBody:
     content:

--- a/redo/api-schema/src/path/returns.path.yaml
+++ b/redo/api-schema/src/path/returns.path.yaml
@@ -1,6 +1,6 @@
 description: List of returns for store.
 get:
-  description: List returns, sorted by most recent to least recent.
+  description: List returns, sorted by most recent to least recent. Requires the [`returns_read`](/docs/api-reference/scopes) scope.
   operationId: Returns list
   parameters:
     - { $ref: ../param/page-continue.param.yaml }
@@ -37,7 +37,7 @@ get:
   summary: List Returns
   tags: [Returns]
 post:
-  description: Create a return for specific order line items.
+  description: Create a return for specific order line items. Requires the [`returns_write`](/docs/api-reference/scopes) scope.
   operationId: Return create
   parameters:
     - { $ref: ../param/idempotency-key.param.yaml }

--- a/redo/api-schema/src/path/storefront-events.path.yaml
+++ b/redo/api-schema/src/path/storefront-events.path.yaml
@@ -1,6 +1,6 @@
 post:
   description:
-    Processes events from storefronts using Shopify pixel event schema
+    Processes events from storefronts using Shopify pixel event schema Requires the [`storefront_events_write`](/docs/api-reference/scopes) scope.
   operationId: Storefront Event
   parameters:
     - $ref: "../param/store-id.param.yaml"

--- a/redo/api-schema/src/path/webhook-replay.path.yaml
+++ b/redo/api-schema/src/path/webhook-replay.path.yaml
@@ -2,7 +2,7 @@ description: Webhook replay.
 parameters:
   - { $ref: ../param/webhook-id.param.yaml }
 post:
-  description: Replay a webhook.
+  description: Replay a webhook. Requires the [`webhooks_write`](/docs/api-reference/scopes) scope.
   operationId: Webhook replay
   requestBody:
     content:

--- a/redo/api-schema/src/path/webhook.path.yaml
+++ b/redo/api-schema/src/path/webhook.path.yaml
@@ -1,5 +1,5 @@
 delete:
-  description: Delete a webhook.
+  description: Delete a webhook. Requires the [`webhooks_write`](/docs/api-reference/scopes) scope.
   operationId: Webhook delete
   parameters:
     - { $ref: "../param/webhook-id.param.yaml" }
@@ -12,7 +12,7 @@ delete:
   tags: [Webhooks]
 description: Webhook.
 get:
-  description: Get a webhook.
+  description: Get a webhook. Requires the [`webhooks_read`](/docs/api-reference/scopes) scope.
   operationId: Webhook get
   parameters:
     - { $ref: ../param/webhook-id.param.yaml }
@@ -29,7 +29,7 @@ get:
   summary: Webhook
   tags: [Webhooks]
 put:
-  description: Update a webhook.
+  description: Update a webhook. Requires the [`webhooks_write`](/docs/api-reference/scopes) scope.
   operationId: Webhook update
   parameters:
     - { $ref: ../param/webhook-id.param.yaml }

--- a/redo/api-schema/src/path/webhooks.path.yaml
+++ b/redo/api-schema/src/path/webhooks.path.yaml
@@ -1,6 +1,6 @@
 description: Webhooks.
 get:
-  description: List webhooks for store.
+  description: List webhooks for store. Requires the [`webhooks_read`](/docs/api-reference/scopes) scope.
   operationId: Webhooks list
   responses:
     "200":
@@ -26,7 +26,7 @@ parameters:
 post:
   description:
     Create webhook for store. Or if webhook already exists with `externalId`,
-    update it.
+    update it. Requires the [`webhooks_write`](/docs/api-reference/scopes) scope.
   operationId: Webhook create
   requestBody:
     content:

--- a/redo/docs.json
+++ b/redo/docs.json
@@ -186,6 +186,7 @@
             "pages": [
               "/docs/api-reference/introduction",
               "/docs/api-reference/authentication",
+              "/docs/api-reference/scopes",
               "/docs/api-reference/errors",
               "/docs/api-reference/pagination",
               "/docs/api-reference/loop-compatible-api"

--- a/redo/docs/api-reference/authentication.mdx
+++ b/redo/docs/api-reference/authentication.mdx
@@ -58,11 +58,11 @@ does not hold it.
 Choose the scopes a client needs when you create its token in **Settings** →
 **Developer**. Every endpoint in this reference lists its required scope.
 
-<Warning>
-  Tokens created before scopes were introduced may not carry any scopes. If a
-  request starts returning `403`, re-issue the token and grant it the required
-  scopes.
-</Warning>
+<Note>
+  Tokens created before access scopes were introduced were granted all scopes,
+  so they keep working unchanged. Newly created tokens only carry the scopes you
+  select.
+</Note>
 
 See [Access scopes](/docs/api-reference/scopes) for the full list and how to
 grant them.

--- a/redo/docs/api-reference/authentication.mdx
+++ b/redo/docs/api-reference/authentication.mdx
@@ -55,8 +55,9 @@ Each endpoint requires a specific scope (for example, listing returns requires
 `returns_read`), and a request is rejected with `403 Forbidden` if the token
 does not hold it.
 
-Choose the scopes a client needs when you create its token in **Settings** →
-**Developer**. Every endpoint in this reference lists its required scope.
+Choose a client's scopes in **Settings** → **Developer** when you create its
+token, and update them at any time without re-issuing the token. Every endpoint
+in this reference lists its required scope.
 
 <Note>
   Tokens created before access scopes were introduced were granted all scopes,

--- a/redo/docs/api-reference/authentication.mdx
+++ b/redo/docs/api-reference/authentication.mdx
@@ -1,7 +1,7 @@
 ---
-title: 'Authentication'
-description: 'How to authenticate your API requests'
-icon: 'key'
+title: "Authentication"
+description: "How to authenticate your API requests"
+icon: "key"
 ---
 
 ## Getting Your Credentials
@@ -21,11 +21,13 @@ To create an API token:
 
 ### Store ID
 
-Your Store ID is displayed in the **General** section of **Settings** → **Developer** in the Redo Dashboard.
+Your Store ID is displayed in the **General** section of **Settings** →
+**Developer** in the Redo Dashboard.
 
 ## API Endpoints
 
-All API endpoints are authenticated using the Bearer authorization scheme with your API secret.
+All API endpoints are authenticated using the Bearer authorization scheme with
+your API secret.
 
 Include your API secret in the `Authorization` header of every request:
 
@@ -46,11 +48,32 @@ curl -X GET "https://api.getredo.com/v2.2/stores/store_123/returns" \
   -H "Authorization: Bearer YOUR_API_SECRET"
 ```
 
+## Access scopes
+
+API tokens carry **access scopes** that determine which endpoints they may call.
+Each endpoint requires a specific scope (for example, listing returns requires
+`returns_read`), and a request is rejected with `403 Forbidden` if the token
+does not hold it.
+
+Choose the scopes a client needs when you create its token in **Settings** →
+**Developer**. Every endpoint in this reference lists its required scope.
+
+<Warning>
+  Tokens created before scopes were introduced may not carry any scopes. If a
+  request starts returning `403`, re-issue the token and grant it the required
+  scopes.
+</Warning>
+
+See [Access scopes](/docs/api-reference/scopes) for the full list and how to
+grant them.
+
 ## Webhooks
 
-Webhooks are authenticated using the Bearer authorization scheme with a secret **you provide** when creating the webhook subscription.
+Webhooks are authenticated using the Bearer authorization scheme with a secret
+**you provide** when creating the webhook subscription.
 
-Redo will include this secret in the `Authorization` header when delivering webhook events to your endpoint:
+Redo will include this secret in the `Authorization` header when delivering
+webhook events to your endpoint:
 
 ```http
 POST /events HTTP/1.1
@@ -58,11 +81,15 @@ Authorization: Bearer subscriberauth123
 Host: subscriber.example.com
 ```
 
-**Always verify the Authorization header** in your webhook handler before processing events.
+**Always verify the Authorization header** in your webhook handler before
+processing events.
 
 ### Webhook Event Delivery
 
-- Webhook events are delivered **in order** for each individual subject (e.g., return)
-- If the response is not a 2xx status code, the event will be retried multiple times before discarding it
+- Webhook events are delivered **in order** for each individual subject (e.g.,
+  return)
+- If the response is not a 2xx status code, the event will be retried multiple
+  times before discarding it
 
-See the [Webhooks guide](/docs/guides/integrations/webhooks) for detailed setup instructions.
+See the [Webhooks guide](/docs/guides/integrations/webhooks) for detailed setup
+instructions.

--- a/redo/docs/api-reference/scopes.mdx
+++ b/redo/docs/api-reference/scopes.mdx
@@ -1,0 +1,65 @@
+---
+title: "Access scopes"
+description:
+  "Scopes that API tokens carry and the endpoints they grant access to"
+icon: "lock"
+---
+
+API tokens carry **access scopes** that determine which endpoints they may call.
+A request is rejected with `403 Forbidden` unless the token holds the scope
+required by the endpoint.
+
+<Warning>
+  Existing tokens created before scopes were introduced may not carry any
+  scopes. If a request starts returning `403`, re-issue the token from the
+  Dashboard and grant it the scopes it needs.
+</Warning>
+
+## Granting scopes
+
+Scopes are assigned to a token when you create it:
+
+1. Log in to your [Redo Dashboard](https://app.getredo.com)
+2. Go to **Settings** → **Developer**
+3. Click **Add API Client**
+4. Select the scopes the client needs, then copy the generated API secret
+
+Grant a client only the scopes it needs — read scopes for endpoints that only
+retrieve data, write scopes for endpoints that create, update, or delete.
+
+## Available scopes
+
+Each endpoint in this reference lists the scope it requires. The full set of
+scopes:
+
+| Scope                     | Access | Grants                                                   |
+| ------------------------- | ------ | -------------------------------------------------------- |
+| `orders_read`             | Read   | Retrieve orders.                                         |
+| `orders_write`            | Write  | Create, update, and delete orders; manage fulfillments.  |
+| `customers_read`          | Read   | Retrieve customers.                                      |
+| `customers_write`         | Write  | Create and update customers and subscriptions.           |
+| `products_write`          | Write  | Bulk upload products.                                    |
+| `returns_read`            | Read   | List and retrieve returns and return tags.               |
+| `returns_write`           | Write  | Create, update, and process returns; manage return tags. |
+| `inventory_read`          | Read   | List inventory items and levels.                         |
+| `inbound_shipments_read`  | Read   | List and retrieve inbound shipments.                     |
+| `invoices_read`           | Read   | List invoices.                                           |
+| `webhooks_read`           | Read   | List and retrieve webhooks.                              |
+| `webhooks_write`          | Write  | Create, update, delete, and replay webhooks.             |
+| `customer_events_write`   | Write  | Create custom customer events.                           |
+| `storefront_events_write` | Write  | Create storefront events.                                |
+
+## Insufficient scope
+
+When a token is missing a required scope, the API returns `403 Forbidden` with a
+problem response:
+
+```json
+{
+  "detail": "This token is missing the required `returns_read` scope",
+  "title": "Insufficient token scope",
+  "type": "com.getredo.api:scope/forbidden"
+}
+```
+
+Re-issue the token with the required scope to resolve it.

--- a/redo/docs/api-reference/scopes.mdx
+++ b/redo/docs/api-reference/scopes.mdx
@@ -9,11 +9,11 @@ API tokens carry **access scopes** that determine which endpoints they may call.
 A request is rejected with `403 Forbidden` unless the token holds the scope
 required by the endpoint.
 
-<Warning>
-  Existing tokens created before scopes were introduced may not carry any
-  scopes. If a request starts returning `403`, re-issue the token from the
-  Dashboard and grant it the scopes it needs.
-</Warning>
+<Note>
+  Tokens created before access scopes were introduced were granted all scopes,
+  so they keep working unchanged. Newly created tokens only carry the scopes you
+  select.
+</Note>
 
 ## Granting scopes
 

--- a/redo/docs/api-reference/scopes.mdx
+++ b/redo/docs/api-reference/scopes.mdx
@@ -17,12 +17,13 @@ required by the endpoint.
 
 ## Granting scopes
 
-Scopes are assigned to a token when you create it:
+Select a token's scopes when you create it, and update them at any time — no
+need to re-issue the token:
 
 1. Log in to your [Redo Dashboard](https://app.getredo.com)
 2. Go to **Settings** → **Developer**
-3. Click **Add API Client**
-4. Select the scopes the client needs, then copy the generated API secret
+3. Create an API client (**Add API Client**) or open an existing one
+4. Select the scopes the client needs and save
 
 Grant a client only the scopes it needs — read scopes for endpoints that only
 retrieve data, write scopes for endpoints that create, update, or delete.
@@ -62,4 +63,5 @@ problem response:
 }
 ```
 
-Re-issue the token with the required scope to resolve it.
+Add the missing scope to the token in the Dashboard to resolve it — you don't
+need to re-issue it.


### PR DESCRIPTION
## Summary

Access tokens for the **v2 REST API** now carry **access scopes**. This documents that and marks the scope required by each endpoint.

## What's included

- **Access scopes reference page** (`/docs/api-reference/scopes`) — the full set of scopes, what each grants, how to grant them on a token, and the `403 Forbidden` "insufficient scope" response.
- **Authentication page** — a new *Access scopes* section explaining tokens now require scopes, with a link to the reference. Added to the API Reference → Getting Started nav.
- **Per-endpoint scopes** — a `Requires the `<scope>` scope.` line (linked to the scopes page) on **39 authenticated operations**, across the OpenAPI source path files, with `openapi.yaml` regenerated. Each scope matches the v2 server's per-endpoint enforcement.

The 5 storefront/redirect endpoints that aren't token-authenticated (`Merchant admin navigate`, `Checkout buttons UI`, `Coverage info navigate`, `Coverage products`, `Customer portal navigate`) are intentionally left without a scope line.

## Validation

- `mintlify validate` — OpenAPI definition is valid
- `bazel test tools/lint:lint_test` — passes
- `mintlify broken-links` — no broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)