### PR TITLE
docs: clarify Hydrogen coverage scopes

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -57,7 +57,7 @@ paths:
   /stores/{storeId}/checkout-buttons-ui:
     description: Generate HTML and CSS for checkout buttons to enable or disable returns coverage.
     get:
-      description: Generate rendered HTML and CSS for checkout buttons.
+      description: Generate rendered HTML and CSS for checkout buttons. This endpoint exposes public storefront coverage data and does not require an access scope.
       operationId: Checkout buttons UI
       parameters:
         - $ref: '#/components/parameters/store-id.param'
@@ -83,7 +83,7 @@ paths:
   /stores/{storeId}/coverage-info:
     description: Navigate to the coverage info page.
     get:
-      description: Navigate to the coverage info page.
+      description: Navigate to the coverage info page. This endpoint exposes public storefront coverage data and does not require an access scope.
       operationId: Coverage info navigate
       parameters:
         - $ref: '#/components/parameters/store-id.param'
@@ -97,7 +97,7 @@ paths:
   /stores/{storeId}/coverage-products:
     description: Available coverage products.
     post:
-      description: Get available coverage products.
+      description: Get available coverage products. This endpoint exposes public storefront coverage data and does not require an access scope.
       operationId: Coverage products
       parameters:
         - $ref: '#/components/parameters/store-id.param'

--- a/redo/api-schema/src/path/checkout-buttons-ui.path.yaml
+++ b/redo/api-schema/src/path/checkout-buttons-ui.path.yaml
@@ -1,6 +1,6 @@
 description: Generate HTML and CSS for checkout buttons to enable or disable returns coverage.
 get:
-  description: Generate rendered HTML and CSS for checkout buttons.
+  description: Generate rendered HTML and CSS for checkout buttons. This endpoint exposes public storefront coverage data and does not require an access scope.
   operationId: Checkout buttons UI
   parameters:
     - { $ref: ../param/store-id.param.yaml }

--- a/redo/api-schema/src/path/coverage-info.path.yaml
+++ b/redo/api-schema/src/path/coverage-info.path.yaml
@@ -1,6 +1,6 @@
 description: Navigate to the coverage info page.
 get:
-  description: Navigate to the coverage info page.
+  description: Navigate to the coverage info page. This endpoint exposes public storefront coverage data and does not require an access scope.
   operationId: Coverage info navigate
   parameters:
     - { $ref: ../param/store-id.param.yaml }

--- a/redo/api-schema/src/path/coverage-products.path.yaml
+++ b/redo/api-schema/src/path/coverage-products.path.yaml
@@ -1,6 +1,6 @@
 description: Available coverage products.
 post:
-  description: Get available coverage products.
+  description: Get available coverage products. This endpoint exposes public storefront coverage data and does not require an access scope.
   operationId: Coverage products
   parameters:
     - { $ref: ../param/store-id.param.yaml }

--- a/redo/docs/api-reference/authentication.mdx
+++ b/redo/docs/api-reference/authentication.mdx
@@ -50,14 +50,18 @@ curl -X GET "https://api.getredo.com/v2.2/stores/store_123/returns" \
 
 ## Access scopes
 
-API tokens carry **access scopes** that determine which endpoints they may call.
-Each endpoint requires a specific scope (for example, listing returns requires
-`returns_read`), and a request is rejected with `403 Forbidden` if the token
-does not hold it.
+API tokens carry **access scopes** that determine which protected endpoints they
+may call. For example, listing returns requires `returns_read`, and a request is
+rejected with `403 Forbidden` if the token does not hold it.
 
 Choose a client's scopes in **Settings** → **Developer** when you create its
-token, and update them at any time without re-issuing the token. Every endpoint
-in this reference lists its required scope.
+token, and update them at any time without re-issuing the token. Endpoints that
+require a scope list it in this reference.
+
+<Note>
+  Public storefront coverage endpoints do not require an access scope. A token
+  used only for those endpoints can be created with no scopes selected.
+</Note>
 
 <Note>
   Tokens created before access scopes were introduced were granted all scopes,

--- a/redo/docs/api-reference/scopes.mdx
+++ b/redo/docs/api-reference/scopes.mdx
@@ -5,9 +5,15 @@ description:
 icon: "lock"
 ---
 
-API tokens carry **access scopes** that determine which endpoints they may call.
-A request is rejected with `403 Forbidden` unless the token holds the scope
-required by the endpoint.
+API tokens carry **access scopes** that determine which protected endpoints they
+may call. A request is rejected with `403 Forbidden` unless the token holds the
+scope required by the endpoint.
+
+<Note>
+  Public storefront coverage endpoints do not require an access scope. A token
+  used only for those endpoints, including a Shopify Hydrogen integration
+  token, can be created with no scopes selected.
+</Note>
 
 <Note>
   Tokens created before access scopes were introduced were granted all scopes,
@@ -30,8 +36,8 @@ retrieve data, write scopes for endpoints that create, update, or delete.
 
 ## Available scopes
 
-Each endpoint in this reference lists the scope it requires. The full set of
-scopes:
+Each endpoint that requires an access scope lists it in this reference. The full
+set of scopes:
 
 | Scope                     | Access | Grants                                                   |
 | ------------------------- | ------ | -------------------------------------------------------- |

--- a/redo/docs/guides/integrations/hydrogen.mdx
+++ b/redo/docs/guides/integrations/hydrogen.mdx
@@ -301,7 +301,11 @@ const { nonce, header, NonceProvider } = createContentSecurityPolicy({
 
 ## API
 
-The utilities provided retrieve all of their information using the Redo public API endpoints described in our documentation at [https://developers.redo.com/](https://developers.redo.com/), specifically the [Get coverage product](https://developers.redo.com/docs/redo-api/beb7bc5b27a0c-get-coverage-products) endpoint.
+The utilities retrieve their information from Redo's public coverage endpoints,
+primarily the [Coverage Products](/api-reference/coverage-products/coverage-products)
+endpoint. These endpoints expose storefront-facing coverage data and do not
+require any access scopes. If you create an API token for this integration,
+leave all access scopes unselected.
 
 ## Speed Optimization
 


### PR DESCRIPTION
## Summary

- clarify that Shopify Hydrogen coverage tokens do not require access scopes
- mark the checkout buttons, coverage info, and coverage products endpoints as public storefront coverage data with no required scope
- fix the Hydrogen guide link to the current Coverage Products reference page
- qualify the general authentication and access-scope guidance for public coverage endpoints

## Validation

- `bazel test tools/lint:lint_test --nocache_test_results --test_output=errors`
- `npx --yes mintlify@4.2.384 openapi-check api-schema/openapi.yaml`
- `npx --yes mintlify@4.2.384 broken-links`