### PR TITLE
docs: document order lookup by Shopify order name

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -1137,7 +1137,7 @@ paths:
   /stores/{storeId}/orders/{orderId}:
     description: Single order operations.
     get:
-      description: Retrieve an existing order from the system, including all fulfillments. The orderId parameter can be either the external order ID you provided when creating the order, or the internal Redo order ID returned from the create order response. Requires the [`orders_read`](/docs/api-reference/scopes) scope.
+      description: Retrieve an existing order from the system, including all fulfillments. The orderId parameter can be the external order ID you provided when creating the order, the internal Redo order ID returned from the create order response, or the Shopify order name (e.g. `#1001`). Requires the [`orders_read`](/docs/api-reference/scopes) scope.
       operationId: Order get
       responses:
         '200':

--- a/redo/api-schema/src/path/order.path.yaml
+++ b/redo/api-schema/src/path/order.path.yaml
@@ -1,6 +1,6 @@
 description: Single order operations.
 get:
-  description: Retrieve an existing order from the system, including all fulfillments. The orderId parameter can be either the external order ID you provided when creating the order, or the internal Redo order ID returned from the create order response. Requires the [`orders_read`](/docs/api-reference/scopes) scope.
+  description: Retrieve an existing order from the system, including all fulfillments. The orderId parameter can be the external order ID you provided when creating the order, the internal Redo order ID returned from the create order response, or the Shopify order name (e.g. `#1001`). Requires the [`orders_read`](/docs/api-reference/scopes) scope.
   operationId: Order get
   responses:
     "200":


### PR DESCRIPTION
## What

Updates the public v2 [Get Order](https://developers.redo.com/api-reference/orders/get-order) endpoint documentation to note that an order can now be resolved by its **Shopify order name** (e.g. `#1001`), in addition to the external order ID and internal Redo order ID.

## Why

[redoapp/redo#53987](https://github.com/redoapp/redo/pull/53987) adds a fallback so `:orderId` also matches `shopify.name`. Per request, this doc change is scoped to the Get Order endpoint only.

## Changes

- `path/order.path.yaml` — Get Order (`Order get`) description
- Regenerated `openapi.yaml` via `bazel run openapi_gen`

## Notes for reviewers

- The `orderId` path parameter is a shared file used by several endpoints, so it was left unchanged to keep this scoped to Get Order; the note lives in the endpoint description instead.
- Source YAML in `redo/api-schema/src/` was edited; `openapi.yaml` is generated and its diff matches the source edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)