### PR TITLE
docs: reflect Shopify order name in Get Order path parameter

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -1139,6 +1139,8 @@ paths:
     get:
       description: Retrieve an existing order from the system, including all fulfillments. The orderId parameter can be the external order ID you provided when creating the order, the internal Redo order ID returned from the create order response, or the Shopify order name (e.g. `#1001`). Requires the [`orders_read`](/docs/api-reference/scopes) scope.
       operationId: Order get
+      parameters:
+        - $ref: '#/components/parameters/order-id-with-name.param'
       responses:
         '200':
           content:
@@ -2584,6 +2586,13 @@ components:
         type: string
     order-id.param:
       description: Order ID. Can be either the external order ID provided when creating the order, or the internal Redo order ID.
+      in: path
+      name: orderId
+      required: true
+      schema:
+        type: string
+    order-id-with-name.param:
+      description: Order ID. Can be the external order ID provided when creating the order, the internal Redo order ID, or the Shopify order name (e.g. `#1001`).
       in: path
       name: orderId
       required: true

--- a/redo/api-schema/src/param/order-id-with-name.param.yaml
+++ b/redo/api-schema/src/param/order-id-with-name.param.yaml
@@ -1,0 +1,6 @@
+description: Order ID. Can be the external order ID provided when creating the order, the internal Redo order ID, or the Shopify order name (e.g. `#1001`).
+in: path
+name: orderId
+required: true
+schema:
+  type: string

--- a/redo/api-schema/src/path/order.path.yaml
+++ b/redo/api-schema/src/path/order.path.yaml
@@ -2,6 +2,8 @@ description: Single order operations.
 get:
   description: Retrieve an existing order from the system, including all fulfillments. The orderId parameter can be the external order ID you provided when creating the order, the internal Redo order ID returned from the create order response, or the Shopify order name (e.g. `#1001`). Requires the [`orders_read`](/docs/api-reference/scopes) scope.
   operationId: Order get
+  parameters:
+    - { $ref: ../param/order-id-with-name.param.yaml }
   responses:
     "200":
       content:


### PR DESCRIPTION
## What

Updates the `orderId` **Path Parameters** row on the [Get Order](https://developers.redo.com/api-reference/orders/get-order) endpoint to note it can also be a **Shopify order name** (e.g. `#1001`).

## Why

Follow-up to #176. That PR updated the Get Order endpoint *description* to mention the Shopify order name (per the fallback added in [redoapp/redo#53987](https://github.com/redoapp/redo/pull/53987)), but the `orderId` Path Parameters row still listed only the two ID types. That row is rendered from the shared `order-id.param`, which is referenced by several endpoints, so it couldn't be edited directly without changing the others.

## Changes

- Adds `param/order-id-with-name.param.yaml` — an `orderId` param whose description includes the Shopify order name.
- References it as an **operation-level** parameter on the Get operation in `path/order.path.yaml`, overriding the shared path-level param for Get Order only.
- Regenerated `openapi.yaml` via `bazel run openapi_gen`.

Delete Order and Create Fulfillment continue to use the shared `order-id.param` and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)