### PR TITLE
docs: fix Get Order orderId param not showing Shopify order name

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -1174,6 +1174,8 @@ paths:
     delete:
       description: Delete an order from the system. The orderId parameter can be either the external order ID you provided when creating the order, or the internal Redo order ID returned from the create order response. Requires the [`orders_write`](/docs/api-reference/scopes) scope.
       operationId: Order delete
+      parameters:
+        - $ref: '#/components/parameters/order-id.param'
       responses:
         '200':
           content:
@@ -1206,7 +1208,6 @@ paths:
         - Orders
     parameters:
       - $ref: '#/components/parameters/store-id.param'
-      - $ref: '#/components/parameters/order-id.param'
     summary: Order
   /stores/{storeId}/orders/{orderId}/fulfillments:
     description: Order fulfillments collection.
@@ -2584,15 +2585,15 @@ components:
       schema:
         example: 64e4d5e837572a4813b73e40
         type: string
-    order-id.param:
-      description: Order ID. Can be either the external order ID provided when creating the order, or the internal Redo order ID.
+    order-id-with-name.param:
+      description: Order ID. Can be the external order ID provided when creating the order, the internal Redo order ID, or the Shopify order name (e.g. `#1001`).
       in: path
       name: orderId
       required: true
       schema:
         type: string
-    order-id-with-name.param:
-      description: Order ID. Can be the external order ID provided when creating the order, the internal Redo order ID, or the Shopify order name (e.g. `#1001`).
+    order-id.param:
+      description: Order ID. Can be either the external order ID provided when creating the order, or the internal Redo order ID.
       in: path
       name: orderId
       required: true

--- a/redo/api-schema/src/path/order.path.yaml
+++ b/redo/api-schema/src/path/order.path.yaml
@@ -33,6 +33,8 @@ get:
 delete:
   description: Delete an order from the system. The orderId parameter can be either the external order ID you provided when creating the order, or the internal Redo order ID returned from the create order response. Requires the [`orders_write`](/docs/api-reference/scopes) scope.
   operationId: Order delete
+  parameters:
+    - { $ref: ../param/order-id.param.yaml }
   responses:
     "200":
       content:
@@ -61,5 +63,4 @@ delete:
   tags: [Orders]
 parameters:
   - { $ref: ../param/store-id.param.yaml }
-  - { $ref: ../param/order-id.param.yaml }
 summary: Order


### PR DESCRIPTION
## What

Makes the `orderId` **Path Parameters** row on the [Get Order](https://developers.redo.com/api-reference/orders/get-order) page actually show the Shopify order name (e.g. `#1001`).

## Why

#177 added an operation-level `orderId` override on Get Order, but the shared `orderId` param was still declared at the **path level** as well. OpenAPI renderers (Mintlify) render the path-level param and ignore the operation-level override, so the Path Parameters row kept showing the old description ("...external order ID..., or the internal Redo order ID.").

## Change

Removes `orderId` from the path-level `parameters` block and declares it **per operation** instead:
- Get Order → `order-id-with-name.param` (includes the Shopify order name)
- Delete Order → the original `order-id.param`

`storeId` stays shared at the path level (no conflict). This eliminates the duplicate `orderId`, so the renderer shows the correct description for each operation. Regenerated `openapi.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)