### PR TITLE
Document totals.shippingFee on return responses and webhooks

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -2357,6 +2357,10 @@ webhooks:
                     amount:
                       amount: '0.00'
                       currency: USD
+                  shippingFee:
+                    amount:
+                      amount: '0.00'
+                      currency: USD
                 tags:
                   - name: VIP customer
                     source: merchant
@@ -5700,6 +5704,14 @@ components:
               type: object
             refund:
               description: Total refund amount excluding shipping
+              properties:
+                amount:
+                  $ref: '#/components/schemas/money.schema'
+              required:
+                - amount
+              type: object
+            shippingFee:
+              description: Return shipping fee paid by the customer, whether charged directly or deducted from the refund, store credit, or exchange. "0.00" when the customer paid nothing.
               properties:
                 amount:
                   $ref: '#/components/schemas/money.schema'

--- a/redo/api-schema/src/schema/return-read.schema.yaml
+++ b/redo/api-schema/src/schema/return-read.schema.yaml
@@ -520,6 +520,16 @@ properties:
             $ref: ./money.schema.yaml
         required: [amount]
         type: object
+      shippingFee:
+        description:
+          Return shipping fee paid by the customer, whether charged directly or
+          deducted from the refund, store credit, or exchange. "0.00" when the
+          customer paid nothing.
+        properties:
+          amount:
+            $ref: ./money.schema.yaml
+        required: [amount]
+        type: object
       storeCredit:
         description: Total store credit amount
         properties:

--- a/redo/api-schema/src/webhook/return.path.yaml
+++ b/redo/api-schema/src/webhook/return.path.yaml
@@ -141,6 +141,8 @@ post:
                 amount: { amount: "0.00", currency: USD }
               charge:
                 amount: { amount: "0.00", currency: USD }
+              shippingFee:
+                amount: { amount: "0.00", currency: USD }
             tags:
               - name: VIP customer
                 source: merchant


### PR DESCRIPTION
- Adds `totals.shippingFee` (customer-paid return shipping fee) to the return read schema and return webhook example
- Regenerated `openapi.yaml`