### PR TITLE
docs: use appcfg config update in Gladly setup

### DIFF
--- a/redo/docs/integrations/returns/other/gladly.mdx
+++ b/redo/docs/integrations/returns/other/gladly.mdx
@@ -145,6 +145,15 @@ account manager to get the Redo Returns app code, then follow the steps below.
   activate:
 
   ```bash
+  appcfg apps config create Gladly/redo_returns/v1.3.0 \
+    --name redo-returns \
+    --config '{ "storeId": "<your-redo-store-id>" }' \
+    --secrets '{ "apiToken": "<your-redo-api-token>" }' \
+    --activate
+  ```
+
+  If the configuration name is already taken, but the app is not active try the following:
+  ```bash
   appcfg apps config update redo-returns \
     --config '{ "storeId": "<your-redo-store-id>" }' \
     --secrets '{ "apiToken": "<your-redo-api-token>" }' \

--- a/redo/docs/integrations/returns/other/gladly.mdx
+++ b/redo/docs/integrations/returns/other/gladly.mdx
@@ -145,8 +145,7 @@ account manager to get the Redo Returns app code, then follow the steps below.
   activate:
 
   ```bash
-  appcfg apps config create Redo/redo_returns/v1.3.0 \
-    --name redo-returns \
+  appcfg apps config update redo-returns \
     --config '{ "storeId": "<your-redo-store-id>" }' \
     --secrets '{ "apiToken": "<your-redo-api-token>" }' \
     --activate


### PR DESCRIPTION
Updates the Gladly Returns integration guide to use `appcfg apps config update redo-returns` instead of `appcfg apps config create Redo/redo_returns/v1.3.0 --name redo-returns` in the "Configure and Activate" step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjvNQdxGkTbR2CMR1zRFJ1