### PR TITLE
Returns Custom Integration section

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -1099,6 +1099,10 @@ paths:
         Syncing the same order ID again updates the existing Redo order, so this is
         safe to call on every order create and update.
 
+        For a walkthrough of the full integration, including field-by-field mapping
+        and a complete example payload, see the
+        [Custom Returns Integration guide](/docs/guides/integrations/custom-returns-integration).
+
         Important: If Redo protection is attached to this order, include a line item with:
         - vendor: "re:do"
         - sku: "x-redo"

--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -40,7 +40,6 @@ tags:
   - name: Coverage Info
   - name: Coverage Products
   - name: Custom Events
-  - name: Custom Integration
   - name: Customer Portal
   - name: Customer Subscriptions
   - name: Customers
@@ -52,6 +51,8 @@ tags:
   - name: Orders
   - name: Products
   - name: Returns
+  - description: Push orders into Redo from a commerce platform Redo does not support directly, so shoppers can return them.
+    name: Returns Custom Integration
   - name: Storefront
   - name: Webhooks
 paths:
@@ -1088,9 +1089,15 @@ paths:
   /stores/{storeId}/custom/orders:
     post:
       description: |
-        Sync a custom order to Redo. This endpoint is used for custom integrations
-        to push order data into the Redo system. Syncing the same order ID again
-        updates the existing Redo order.
+        Sync an order to Redo so your shoppers can return it.
+
+        This is the returns integration path for commerce platforms Redo does not
+        support directly. Orders pushed here become returnable: the shopper can look
+        up the order in the return portal, and Redo uses the line items, discounts,
+        and taxes you send to decide what is eligible for return and what to refund.
+
+        Syncing the same order ID again updates the existing Redo order, so this is
+        safe to call on every order create and update.
 
         Important: If Redo protection is attached to this order, include a line item with:
         - vendor: "re:do"
@@ -1153,7 +1160,7 @@ paths:
         - Bearer: []
       summary: Sync Custom Order
       tags:
-        - Custom Integration
+        - Returns Custom Integration
   /stores/{storeId}/orders:
     description: Orders collection.
     post:
@@ -4539,7 +4546,11 @@ components:
       type: object
     custom-order-sync.schema:
       description: |
-        Custom order integration schema for syncing orders to Redo.
+        An order synced into Redo so it can be returned.
+
+        Redo reads the line items, discounts, and taxes below to decide what the
+        shopper is allowed to return and what to refund, so send the values that were
+        actually charged.
 
         Note: If Redo is attached to this order, you must add a single line item with:
         - vendor: "re:do"

--- a/redo/api-schema/src/openapi.yaml
+++ b/redo/api-schema/src/openapi.yaml
@@ -46,7 +46,6 @@ tags:
   - name: Coverage Info
   - name: Coverage Products
   - name: Custom Events
-  - name: Custom Integration
   - name: Customer Portal
   - name: Customer Subscriptions
   - name: Customers
@@ -58,6 +57,10 @@ tags:
   - name: Orders
   - name: Products
   - name: Returns
+  - description:
+      Push orders into Redo from a commerce platform Redo does not support
+      directly, so shoppers can return them.
+    name: Returns Custom Integration
   - name: Storefront
   - name: Webhooks
 paths:
@@ -100,8 +103,9 @@ paths:
   /stores/{storeId}/invoices: { $ref: path/return-payout-object-list.path.yaml }
   # Merchant Admin
   /stores/{storeId}/admin: { $ref: path/admin.path.yaml }
-  # Orders
+  # Returns Custom Integration
   /stores/{storeId}/custom/orders: { $ref: path/custom-order-sync.path.yaml }
+  # Orders
   /stores/{storeId}/orders: { $ref: path/orders.path.yaml }
   /stores/{storeId}/orders/{orderId}: { $ref: path/order.path.yaml }
   /stores/{storeId}/orders/{orderId}/fulfillments:

--- a/redo/api-schema/src/path/custom-order-sync.path.yaml
+++ b/redo/api-schema/src/path/custom-order-sync.path.yaml
@@ -10,6 +10,10 @@ post:
     Syncing the same order ID again updates the existing Redo order, so this is
     safe to call on every order create and update.
 
+    For a walkthrough of the full integration, including field-by-field mapping
+    and a complete example payload, see the
+    [Custom Returns Integration guide](/docs/guides/integrations/custom-returns-integration).
+
     Important: If Redo protection is attached to this order, include a line item with:
     - vendor: "re:do"
     - sku: "x-redo"

--- a/redo/api-schema/src/path/custom-order-sync.path.yaml
+++ b/redo/api-schema/src/path/custom-order-sync.path.yaml
@@ -1,8 +1,14 @@
 post:
   description: |
-    Sync a custom order to Redo. This endpoint is used for custom integrations
-    to push order data into the Redo system. Syncing the same order ID again
-    updates the existing Redo order.
+    Sync an order to Redo so your shoppers can return it.
+
+    This is the returns integration path for commerce platforms Redo does not
+    support directly. Orders pushed here become returnable: the shopper can look
+    up the order in the return portal, and Redo uses the line items, discounts,
+    and taxes you send to decide what is eligible for return and what to refund.
+
+    Syncing the same order ID again updates the existing Redo order, so this is
+    safe to call on every order create and update.
 
     Important: If Redo protection is attached to this order, include a line item with:
     - vendor: "re:do"
@@ -67,4 +73,4 @@ post:
     - Bearer: []
   summary: Sync Custom Order
   tags:
-    - Custom Integration
+    - Returns Custom Integration

--- a/redo/api-schema/src/schema/custom-order/custom-order-sync.schema.yaml
+++ b/redo/api-schema/src/schema/custom-order/custom-order-sync.schema.yaml
@@ -1,6 +1,10 @@
 # $schema: https://json-schema.org/draft/2020-12/schema#
 description: |
-  Custom order integration schema for syncing orders to Redo.
+  An order synced into Redo so it can be returned.
+
+  Redo reads the line items, discounts, and taxes below to decide what the
+  shopper is allowed to return and what to refund, so send the values that were
+  actually charged.
 
   Note: If Redo is attached to this order, you must add a single line item with:
   - vendor: "re:do"

--- a/redo/docs.json
+++ b/redo/docs.json
@@ -200,10 +200,6 @@
             ]
           },
           {
-            "group": "Guides",
-            "pages": ["/docs/guides/integrations/custom-returns-integration"]
-          },
-          {
             "group": "Endpoints",
             "openapi": { "source": "api-schema/openapi.yaml" }
           }

--- a/redo/docs/guides/integrations/custom-returns-integration.mdx
+++ b/redo/docs/guides/integrations/custom-returns-integration.mdx
@@ -49,6 +49,10 @@ POST https://api.getredo.com/v2.2/stores/{storeId}/custom/orders
 |-----------|-------------|
 | `storeId` | Your store ID, found in **Settings** → **Developer** in the Redo Dashboard |
 
+For the full request and response schema, see
+[Sync Custom Order](/api-reference/returns-custom-integration/sync-custom-order)
+in the API reference.
+
 ### Headers
 
 ```
@@ -433,6 +437,7 @@ must conform to this schema for successful synchronization.
 
 If you have questions about implementing this integration or need assistance
 with schema validation, contact our support team at
-[support@getredo.com](mailto:support@getredo.com) or check our
-[API Reference](/docs/api-reference/introduction) for additional endpoint
-documentation.
+[support@getredo.com](mailto:support@getredo.com) or check
+[Sync Custom Order](/api-reference/returns-custom-integration/sync-custom-order)
+and the rest of the [API Reference](/docs/api-reference/introduction) for
+additional endpoint documentation.


### PR DESCRIPTION
- Renames the `Custom Integration` API reference section to `Returns Custom Integration` and gives the tag a description
- Reframes the endpoint and request schema descriptions around what the endpoint is for: syncing orders so shoppers can return them
- Removes the Custom Returns Integration guide from the API Reference tab; it stays under Guides
- Cross-links the guide and the Sync Custom Order endpoint page in both directions