### PR TITLE
Correct Redo coverage line item values in custom returns integration docs

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -1099,16 +1099,15 @@ paths:
         Syncing the same order ID again updates the existing Redo order, so this is
         safe to call on every order create and update.
 
-        For guidance on choosing line item IDs, sending fulfillments, and marking
-        coverage, see the
+        For a walkthrough of the full integration, including field-by-field mapping
+        and a complete example payload, see the
         [Custom Returns Integration guide](/docs/guides/integrations/custom-returns-integration).
 
         Important: If Redo protection is attached to this order, include a line item with:
         - vendor: "re:do"
         - sku: "x-redo"
-        - priceSet: the full price the shopper paid for coverage
-        - tags: "returns", "package protection", "both", or "final sale"
-        - properties: _redo_type with value "returns", "package protection", "both", or "returns,final sale"
+        - tags: "returns", "package protection", or "both"
+        - properties: _redo_type with value "return", "package protection", or "both"
       operationId: Custom Order Sync
       parameters:
         - $ref: '#/components/parameters/store-id.param'

--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -1099,15 +1099,16 @@ paths:
         Syncing the same order ID again updates the existing Redo order, so this is
         safe to call on every order create and update.
 
-        For a walkthrough of the full integration, including field-by-field mapping
-        and a complete example payload, see the
+        For guidance on choosing line item IDs, sending fulfillments, and marking
+        coverage, see the
         [Custom Returns Integration guide](/docs/guides/integrations/custom-returns-integration).
 
         Important: If Redo protection is attached to this order, include a line item with:
         - vendor: "re:do"
         - sku: "x-redo"
-        - tags: "returns", "package protection", or "both"
-        - properties: _redo_type with value "return", "package protection", or "both"
+        - priceSet: the full price the shopper paid for coverage
+        - tags: "returns", "package protection", "both", or "final sale"
+        - properties: _redo_type with value "returns", "package protection", "both", or "returns,final sale"
       operationId: Custom Order Sync
       parameters:
         - $ref: '#/components/parameters/store-id.param'

--- a/redo/docs/guides/integrations/custom-returns-integration.mdx
+++ b/redo/docs/guides/integrations/custom-returns-integration.mdx
@@ -6,21 +6,10 @@ icon: "code"
 
 ## Overview
 
-This guide helps you integrate your custom e-commerce platform or order
-management system with Redo by syncing orders through our dedicated orders
-endpoint. This integration allows you to programmatically send order data to
-Redo, enabling seamless returns and package protection for your customers.
+Sync orders from a custom e-commerce platform, an unsupported platform, or your
+own middleware into Redo, so your customers get returns and package protection.
 
-## When to Use This Integration
-
-Use the custom integration orders endpoint when:
-
-- You have a custom-built e-commerce platform
-- Your platform isn't directly supported by Redo
-- You need programmatic control over order synchronization
-- You're building a middleware integration between your systems
-
-## Integration Flow
+## Integration flow
 
 ```mermaid
 flowchart TD
@@ -47,11 +36,9 @@ Your `storeId` is in **Settings → Developer** in the Redo Dashboard, where you
 also generate the API secret. See
 [Authentication](/docs/api-reference/authentication) for how to send it.
 
-**The full request and response schema, every field, and a complete example
+The full request and response schema, every field, and a complete example
 payload live in
-[Sync Custom Order](/api-reference/returns-custom-integration/sync-custom-order).**
-This guide covers the parts the schema cannot tell you: what to put in the
-fields, and how Redo interprets them.
+[Sync Custom Order](/api-reference/returns-custom-integration/sync-custom-order).
 
 Syncing the same order `id` again updates the existing Redo order, so the
 endpoint is safe to call on every order create and update.
@@ -60,20 +47,16 @@ endpoint is safe to call on every order create and update.
 
 ### Line item IDs
 
-`id` identifies one line on one order, not a product.
+`id` identifies one line on one order, not a product. Use `productId` and `sku`
+for product identity — those are meant to repeat across orders.
 
-- It must be unique **within** an order — duplicates are rejected with a `400`
-- It must be **stable for that order** across re-syncs. Returns reference it, so
-  regenerating IDs on every sync orphans existing returns
-- Do **not** reuse the same `id` across orders for the same product. Some
-  lookups match on line item ID across a store's orders and will pull in
-  unrelated orders
-- Avoid underscores. `id` is combined with an index internally using `_` as the
-  separator, so an underscore in the ID does not round-trip
+- Unique **within** an order — duplicates are rejected with a `400`
+- **Stable across re-syncs** — returns reference it, so regenerating IDs orphans
+  existing returns
+- Not reused across orders
+- No underscores
 
 A per-order counter such as `ORD1234-1`, `ORD1234-2` satisfies all of these.
-Cross-order product identity belongs in `productId` and `sku`, which are meant
-to repeat.
 
 ### Money
 
@@ -95,8 +78,7 @@ return portal. Send a fulfillment once the order ships, and include
 `deliveryDate` if your return window should start at delivery rather than at
 order creation.
 
-Shipping lines are separate — they carry what the shopper paid for shipping and
-do not affect what is returnable.
+Shipping lines do not affect what is returnable.
 
 ## Coverage
 
@@ -122,19 +104,14 @@ both — you **must** include a line item with these exact values:
 }
 ```
 
-`priceSet` must be the **full** price of the coverage item — the entire amount
-the shopper paid for it, before any splits or deductions. When one line item
-covers more than one type of coverage, send the combined total.
+`priceSet` must be the **full** amount the shopper paid for coverage. When one
+line item covers more than one type, send the combined total.
 
-When `_redo_type` is present it takes precedence over `tags`. Send one or the
-other consistently; sending a `_redo_type` that covers less than the tags do
-will under-report the coverage purchased.
+If both are sent, `_redo_type` wins over `tags`. Keep them in sync.
 
 ### Final sale
 
-Final sale returns coverage is billed separately from base returns coverage, so
-the payload has to say when the shopper bought it. Add `final sale` alongside
-`returns`:
+When the shopper buys final sale returns coverage, mark it alongside `returns`:
 
 ```typescript
 tags: ["returns", "final sale"]
@@ -142,32 +119,16 @@ tags: ["returns", "final sale"]
 properties: [{ name: "_redo_type", value: "returns,final sale" }]
 ```
 
-An explicit property is also accepted, and wins on its own:
-
-```typescript
-properties: [
-  { name: "_redo_type", value: "returns" },
-  { name: "__final_sale_coverage", value: "true" }
-]
-```
-
-Any of these marks the order as final-sale covered **and** as returns covered —
-final sale coverage always implies returns coverage. Without one of them, final
-sale is only applied when your Redo settings cover every order or mark all Redo
-purchases as final sale.
+Final sale coverage always implies returns coverage. Without this, final sale
+only applies if your Redo settings cover every order.
 
 ### Package Protection Plus
 
-Package Protection Plus is configured in your Redo settings, not on the order
-payload.
-
-- **Shopper-paid** — include the Redo line item above with
+- **Shopper-paid** — include the coverage line item with
   `_redo_type: "package protection"` (or `"both"`), priced at what the shopper
   paid.
-- **Merchant-paid per order** or **all orders covered** — send no Redo line
-  item. Redo applies coverage to every order that falls inside the enabled date
-  range and whose items are not excluded by your protection exclusion tags or
-  collections.
+- **Merchant-paid or all orders covered** — send no coverage line item. Redo
+  applies it based on your Redo settings.
 
 ## Next steps
 

--- a/redo/docs/guides/integrations/custom-returns-integration.mdx
+++ b/redo/docs/guides/integrations/custom-returns-integration.mdx
@@ -315,12 +315,49 @@ must conform to this schema for successful synchronization.
   properties: [
     {
       name: "_redo_type",
-      value: "return"           // "return", "package protection", or "both"
+      value: "returns"          // "returns", "package protection", or "both"
     }
   ],
   // ... other standard line item fields
 }
 ```
+
+`priceSet` on this line item is the amount the shopper paid for coverage. It
+drives billing — omit it and the coverage is treated as unpaid.
+
+When `_redo_type` is present it takes precedence over `tags`. Send one or the
+other consistently; sending a `_redo_type` that covers less than the tags do
+will under-report the coverage purchased.
+
+  <Note>
+  Final sale returns coverage is a **separate** purchase from base returns
+  coverage. When the shopper bought it, add a `__final_sale_coverage` property to
+  the same Redo line item:
+  </Note>
+
+```typescript
+properties: [
+  { name: "_redo_type", value: "returns" },
+  { name: "__final_sale_coverage", value: "true" }
+]
+```
+
+Without this property, final sale returns are only applied when your Redo
+settings cover every order.
+
+</Accordion>
+
+<Accordion title="Package Protection Plus">
+  Package Protection Plus is configured in your Redo settings, not on the order
+  payload.
+
+- **Shopper-paid** — include the Redo line item above with
+  `_redo_type: "package protection"` (or `"both"`), priced at what the shopper
+  paid.
+- **Merchant-paid per order** or **all orders covered** — send no Redo line
+  item. Redo applies coverage to every order that falls inside the enabled date
+  range and whose items are not excluded by your protection exclusion tags or
+  collections.
 
 </Accordion>
 
@@ -381,6 +418,31 @@ must conform to this schema for successful synchronization.
           "unit": "g"
         },
         "image": "https://example.com/images/tee.jpg"
+      },
+      {
+        "id": "line_2",
+        "productId": "redo-coverage",
+        "sku": "x-redo",
+        "title": "Redo Returns Coverage",
+        "vendor": "re:do",
+        "quantity": 1,
+        "priceSet": {
+          "presentmentMoney": {
+            "amount": "3.49",
+            "currencyCode": "USD"
+          },
+          "shopMoney": {
+            "amount": "3.49",
+            "currencyCode": "USD"
+          }
+        },
+        "tags": ["returns"],
+        "properties": [
+          {
+            "name": "_redo_type",
+            "value": "returns"
+          }
+        ]
       }
     ],
     "shippingLines": [
@@ -405,7 +467,7 @@ must conform to this schema for successful synchronization.
     "transactions": [
       {
         "paymentId": "pay_abc123",
-        "amount": 65.97,
+        "amount": 69.46,
         "currency": "USD",
         "createdDate": "2025-01-15T10:30:00Z",
         "paymentGateway": "stripe"

--- a/redo/docs/guides/integrations/custom-returns-integration.mdx
+++ b/redo/docs/guides/integrations/custom-returns-integration.mdx
@@ -37,273 +37,73 @@ flowchart TD
     class A,B,C,D,E,F,G,H transparent
 ```
 
-## Endpoint
-
-Send order data to the following endpoint:
+## The endpoint
 
 ```
 POST https://api.getredo.com/v2.2/stores/{storeId}/custom/orders
 ```
 
-| Parameter | Description |
-|-----------|-------------|
-| `storeId` | Your store ID, found in **Settings** → **Developer** in the Redo Dashboard |
+Your `storeId` is in **Settings → Developer** in the Redo Dashboard, where you
+also generate the API secret. See
+[Authentication](/docs/api-reference/authentication) for how to send it.
 
-For the full request and response schema, see
-[Sync Custom Order](/api-reference/returns-custom-integration/sync-custom-order)
-in the API reference.
+**The full request and response schema, every field, and a complete example
+payload live in
+[Sync Custom Order](/api-reference/returns-custom-integration/sync-custom-order).**
+This guide covers the parts the schema cannot tell you: what to put in the
+fields, and how Redo interprets them.
 
-### Headers
+Syncing the same order `id` again updates the existing Redo order, so the
+endpoint is safe to call on every order create and update.
 
-```
-Authorization: Bearer YOUR_API_SECRET
-Content-Type: application/json
-```
+## Getting the values right
 
-### Response
+### Line item IDs
 
-A successful request returns:
+`id` identifies one line on one order, not a product.
 
-```json
-{
-  "message": "Order synced successfully",
-  "orderId": "your_order_id",
-  "redoId": "68b1f0c2a4d1e90012ab34cd"
-}
-```
+- It must be unique **within** an order — duplicates are rejected with a `400`
+- It must be **stable for that order** across re-syncs. Returns reference it, so
+  regenerating IDs on every sync orphans existing returns
+- Do **not** reuse the same `id` across orders for the same product. Some
+  lookups match on line item ID across a store's orders and will pull in
+  unrelated orders
+- Avoid underscores. `id` is combined with an index internally using `_` as the
+  separator, so an underscore in the ID does not round-trip
 
-| Field | Description |
-|-------|-------------|
-| `orderId` | The order ID you sent in the request body |
-| `redoId` | The Redo order ID for the synced order |
+A per-order counter such as `ORD1234-1`, `ORD1234-2` satisfies all of these.
+Cross-order product identity belongs in `productId` and `sku`, which are meant
+to repeat.
 
-Syncing the same `id` again updates the existing Redo order, so this endpoint is
-safe to call on every order create and update.
+### Money
 
-A validation failure returns a `400` with the offending fields:
+Send amounts as strings to avoid floating-point drift, and currency codes as
+ISO 4217. Line item `priceSet` is **pre-tax and pre-discount**.
 
-```json
-{
-  "error": "Invalid order payload",
-  "errors": { "properties": { "lineItems": { "errors": ["Invalid input"] } } }
-}
-```
+### Quantities, taxes and discounts
 
-## Order Schema
+`quantity` is the amount ordered; `returnableQuantity` is how much is eligible
+for return, which may be lower. Line item `taxLines` and `discounts` are totals
+for **all units** on the line — quantity × per-unit — not per-unit values.
+Shipping lines follow the same rule.
 
-The orders endpoint accepts order data in the following structure. All fields
-must conform to this schema for successful synchronization.
+### Fulfillments
 
-<AccordionGroup>
-  <Accordion title="Order Object">
-    ```typescript
-    {
-      id: string;                    // Unique order identifier
-      type: "order";                 // Must be literal "order"
-      createdAt: string;            // ISO 8601 timestamp
-      updatedAt: string;            // ISO 8601 timestamp
-      presentmentCurrency: string;  // Currency shown to customer
-      shopCurrency: string;         // Your shop's base currency
-      tags?: string[];              // Optional order tags
-      salesChannel?: string | null; // Sales channel identifier
-      customer: {
-        id?: string;                // Optional customer identifier
-        email: string;              // Required email address
-        firstName: string;          // Customer first name
-        lastName: string;           // Customer last name
-        phone?: string | null;      // Optional phone number
-        tags?: string[];            // Optional customer tags
-      },
-      shippingAddress: {
-        address1: string;           // Primary address line
-        address2?: string | null;   // Secondary address line
-        city: string;               // City name
-        company?: string | null;    // Company name
-        firstName?: string | null;
-        lastName?: string | null;
-        provinceCode: string;       // State/province code
-        zip: string;                // Postal code
-        countryCode: string;        // ISO country code
-        phone?: string | null;      // Contact phone
-      },
-      billingAddress?: {            // Optional, same structure as shippingAddress
-        address1?: string;
-        address2?: string | null;
-        city?: string;
-        company?: string | null;
-        firstName?: string | null;
-        lastName?: string | null;
-        provinceCode?: string;
-        zip?: string;
-        countryCode?: string;
-        phone?: string | null;
-      },
-      lineItems: [/* See Line Items section below */],
-      shippingLines: [
-        {
-          id: string;
-          title: string;            // Shipping method name
-          code?: string;            // Shipping method code
-          priceSet: {               // Pre-tax, pre-discount price
-            presentmentMoney: { amount: string, currencyCode: string },
-            shopMoney: { amount: string, currencyCode: string }
-          },
-          discounts?: [/* Same structure as line item discounts */],
-          taxLines?: [/* Same structure as line item taxes */]
-        }
-      ],
-      orderDiscounts: [
-        {
-          discountId: string;
-          discountTitle?: string;
-          discountCode?: string;
-          amountSet: {
-            presentmentMoney: { amount: string, currencyCode: string },
-            shopMoney: { amount: string, currencyCode: string }
-          }
-        }
-      ],
-      fulfillments: [
-        {
-          id: string;
-          shippingDate?: string | null;    // ISO 8601 timestamp
-          deliveryDate?: string | null;    // ISO 8601 timestamp
-          trackingNumbers?: [
-            {
-              carrier?: string | null;
-              trackingNumber: string;
-            }
-          ],
-          trackingUrls?: string[];
-          lineItems: [
-            {
-              id: string;                  // References line item ID
-              quantity: number;            // Fulfilled quantity
-            }
-          ]
-        }
-      ],
-      transactions?: [
-        {
-          paymentId: string;
-          amount: number;
-          currency: string;
-          createdDate: string;         // ISO 8601 timestamp
-          paymentGateway: string;      // Payment processor name
-          additionalDetails?: {        // Required when paymentGateway is "authorize_net"
-            creditCardLastFour: string; // Exactly 4 digits
-          }
-        }
-      ]
-    }
-    ```
-  </Accordion>
+Fulfillments are what make items returnable. Unless your Redo settings allow
+returns on unfulfilled items, a line with no fulfillment never appears in the
+return portal. Send a fulfillment once the order ships, and include
+`deliveryDate` if your return window should start at delivery rather than at
+order creation.
 
-  <Accordion title="Line Items">
-    Each order must include at least one line item:
+Shipping lines are separate — they carry what the shopper paid for shipping and
+do not affect what is returnable.
 
-    ```typescript
-    lineItems: [
-      {
-        id: string;                      // Unique line item ID
-        productId: string;               // Product identifier
-        variantId?: string | null;       // Variant identifier
-        additionalProductId?: string | null;
-        sku: string;                     // Stock keeping unit
-        title: string;                   // Product title
-        variantTitle?: string | null;    // Variant name
-        vendor?: string | null;          // Vendor name
-        fulfillmentService?: string | null;
-        quantity: number;                // Quantity ordered
-        returnableQuantity?: number | null; // Qty eligible for return
-        priceSet: {                      // Pre-tax, pre-discount price
-          presentmentMoney: {
-            amount: string;
-            currencyCode: string;
-          },
-          shopMoney: {
-            amount: string;
-            currencyCode: string;
-          }
-        },
-        weight?: {
-          value: number;               // Grams
-          unit: string;                // Label only; value is read as grams
-        } | null,
-        image?: string | null;           // Primary image URL — the one Redo displays
-        images?: [                       // Accepted, but not currently displayed
-          {
-            url: string;
-            data?: string | null;        // Base64 image data
-          }
-        ],
-        properties?: [                   // Custom properties
-          {
-            name: string;
-            value: string;
-          }
-        ],
-        tags?: string[];
-        discounts?: [                    // Line item discounts
-          {
-            discountId: string;
-            discountTitle?: string;
-            discountCode?: string;
-            amountSet: {
-              presentmentMoney: { amount: string, currencyCode: string },
-              shopMoney: { amount: string, currencyCode: string }
-            }
-          }
-        ],
-        taxLines?: [                     // Line item taxes
-          {
-            title?: string;
-            rate: string | null;
-            priceSet: {
-              presentmentMoney: { amount: string, currencyCode: string },
-              shopMoney: { amount: string, currencyCode: string }
-            }
-          }
-        ]
-      }
-    ]
-    ```
+## Coverage
 
-  </Accordion>
-</AccordionGroup>
+### The Redo coverage line item
 
-## Important Notes
-
-### Money Values
-
-- Use string values for amounts to avoid floating-point precision issues
-- Currency codes should follow ISO 4217 standards
-
-### Line Item IDs
-
-- `id` must be unique within an order — duplicate IDs are rejected with a `400`
-- Fulfillment `lineItems[].id` must reference a line item `id` on the same order
-
-### Quantities
-
-- `quantity`: Total quantity ordered
-- `returnableQuantity`: Quantity eligible for return (may differ from quantity
-  for partially fulfilled orders)
-- Discount and tax amounts should account for quantity
-
-### Tax and Discount Calculation
-
-- Line item `taxLines` should reflect the total tax for all units (quantity ×
-  per-unit tax)
-- Line item `discounts` should reflect the total discount for all units
-- Shipping `taxLines` and `discounts` follow the same pattern
-
-## Additional Considerations
-
-<Accordion title="Redo Protection Line Items">
-  <Note>
-  When a customer has purchased Redo protection (returns, package protection, or both), you **must** include a special line item with these exact values:
-  </Note>
+When a shopper has purchased Redo protection — returns, package protection, or
+both — you **must** include a line item with these exact values:
 
 ```typescript
 {
@@ -330,11 +130,11 @@ When `_redo_type` is present it takes precedence over `tags`. Send one or the
 other consistently; sending a `_redo_type` that covers less than the tags do
 will under-report the coverage purchased.
 
-  <Note>
-  Final sale returns coverage is billed separately from base returns coverage,
-  so the order payload has to say when the shopper bought it. Add `final sale`
-  alongside `returns`:
-  </Note>
+### Final sale
+
+Final sale returns coverage is billed separately from base returns coverage, so
+the payload has to say when the shopper bought it. Add `final sale` alongside
+`returns`:
 
 ```typescript
 tags: ["returns", "final sale"]
@@ -356,11 +156,10 @@ final sale coverage always implies returns coverage. Without one of them, final
 sale is only applied when your Redo settings cover every order or mark all Redo
 purchases as final sale.
 
-</Accordion>
+### Package Protection Plus
 
-<Accordion title="Package Protection Plus">
-  Package Protection Plus is configured in your Redo settings, not on the order
-  payload.
+Package Protection Plus is configured in your Redo settings, not on the order
+payload.
 
 - **Shopper-paid** — include the Redo line item above with
   `_redo_type: "package protection"` (or `"both"`), priced at what the shopper
@@ -370,147 +169,21 @@ purchases as final sale.
   range and whose items are not excluded by your protection exclusion tags or
   collections.
 
-</Accordion>
-
-## Example Request
-
-<Accordion title="View Example Request">
-  ```json
-  {
-    "id": "order_123456",
-    "type": "order",
-    "createdAt": "2025-01-15T10:30:00Z",
-    "updatedAt": "2025-01-15T10:30:00Z",
-    "presentmentCurrency": "USD",
-    "shopCurrency": "USD",
-    "salesChannel": "web",
-    "tags": ["vip-customer"],
-    "customer": {
-      "id": "cust_789",
-      "email": "customer@example.com",
-      "firstName": "Jane",
-      "lastName": "Doe",
-      "phone": "+1234567890"
-    },
-    "shippingAddress": {
-      "address1": "123 Main St",
-      "address2": "Apt 4B",
-      "city": "New York",
-      "provinceCode": "NY",
-      "zip": "10001",
-      "countryCode": "US",
-      "firstName": "Jane",
-      "lastName": "Doe",
-      "phone": "+1234567890"
-    },
-    "lineItems": [
-      {
-        "id": "line_1",
-        "productId": "prod_456",
-        "variantId": "var_789",
-        "sku": "TEE-BLK-M",
-        "title": "Classic T-Shirt",
-        "variantTitle": "Black / Medium",
-        "vendor": "Acme Apparel",
-        "quantity": 2,
-        "returnableQuantity": 2,
-        "priceSet": {
-          "presentmentMoney": {
-            "amount": "29.99",
-            "currencyCode": "USD"
-          },
-          "shopMoney": {
-            "amount": "29.99",
-            "currencyCode": "USD"
-          }
-        },
-        "weight": {
-          "value": 227,
-          "unit": "g"
-        },
-        "image": "https://example.com/images/tee.jpg"
-      },
-      {
-        "id": "line_2",
-        "productId": "redo-coverage",
-        "sku": "x-redo",
-        "title": "Redo Returns Coverage",
-        "vendor": "re:do",
-        "quantity": 1,
-        "priceSet": {
-          "presentmentMoney": {
-            "amount": "3.49",
-            "currencyCode": "USD"
-          },
-          "shopMoney": {
-            "amount": "3.49",
-            "currencyCode": "USD"
-          }
-        },
-        "tags": ["returns"],
-        "properties": [
-          {
-            "name": "_redo_type",
-            "value": "returns"
-          }
-        ]
-      }
-    ],
-    "shippingLines": [
-      {
-        "id": "ship_1",
-        "title": "Standard Shipping",
-        "code": "standard",
-        "priceSet": {
-          "presentmentMoney": {
-            "amount": "5.99",
-            "currencyCode": "USD"
-          },
-          "shopMoney": {
-            "amount": "5.99",
-            "currencyCode": "USD"
-          }
-        }
-      }
-    ],
-    "orderDiscounts": [],
-    "fulfillments": [],
-    "transactions": [
-      {
-        "paymentId": "pay_abc123",
-        "amount": 69.46,
-        "currency": "USD",
-        "createdDate": "2025-01-15T10:30:00Z",
-        "paymentGateway": "stripe"
-      }
-    ]
-  }
-  ```
-</Accordion>
-
-## Next Steps
+## Next steps
 
 <Steps>
-  <Step title="Get API Credentials">
-    Log in to your [Redo Dashboard](https://app.getredo.com), go to **Settings** → **Developer**, and click **Add API Client** to generate your API secret. See [Authentication](/docs/api-reference/authentication) for details.
+  <Step title="Get API credentials">
+    In the [Redo Dashboard](https://app.getredo.com), go to **Settings → Developer** and click **Add API Client**.
   </Step>
-  <Step title="Map Your Order Data">
-    Transform your order data to match the required schema
+  <Step title="Map your orders">
+    Follow [Sync Custom Order](/api-reference/returns-custom-integration/sync-custom-order) for the field-by-field schema.
   </Step>
-  <Step title="Implement the Integration">
-    Build your integration to POST orders to `https://api.getredo.com/v2.2/stores/{storeId}/custom/orders` when created or
-    updated
-  </Step>
-  <Step title="Test Thoroughly">
-    Validate your integration with test orders before going live
+  <Step title="Send test orders">
+    Validate with test orders, including one with a coverage line item, before going live.
   </Step>
 </Steps>
 
-## Need Help?
+## Need help?
 
-If you have questions about implementing this integration or need assistance
-with schema validation, contact our support team at
-[support@getredo.com](mailto:support@getredo.com) or check
-[Sync Custom Order](/api-reference/returns-custom-integration/sync-custom-order)
-and the rest of the [API Reference](/docs/api-reference/introduction) for
-additional endpoint documentation.
+Contact [support@getredo.com](mailto:support@getredo.com), or see the
+[API Reference](/docs/api-reference/introduction).

--- a/redo/docs/guides/integrations/custom-returns-integration.mdx
+++ b/redo/docs/guides/integrations/custom-returns-integration.mdx
@@ -322,9 +322,6 @@ must conform to this schema for successful synchronization.
 }
 ```
 
-`priceSet` on this line item is the amount the shopper paid for coverage. It
-drives billing — omit it and the coverage is treated as unpaid.
-
 When `_redo_type` is present it takes precedence over `tags`. Send one or the
 other consistently; sending a `_redo_type` that covers less than the tags do
 will under-report the coverage purchased.

--- a/redo/docs/guides/integrations/custom-returns-integration.mdx
+++ b/redo/docs/guides/integrations/custom-returns-integration.mdx
@@ -310,7 +310,7 @@ must conform to this schema for successful synchronization.
   id: string,                    // Unique ID for this line item
   vendor: "re:do",              // Exactly "re:do"
   sku: "x-redo",                // Exactly "x-redo"
-  priceSet: { /* Redo fee amount */ },
+  priceSet: { /* Full coverage price paid */ },
   tags: ["returns"],            // One or more: "returns", "package protection", "both"
   properties: [
     {
@@ -321,6 +321,10 @@ must conform to this schema for successful synchronization.
   // ... other standard line item fields
 }
 ```
+
+`priceSet` must be the **full** price of the coverage item — the entire amount
+the shopper paid for it, before any splits or deductions. When one line item
+covers more than one type of coverage, send the combined total.
 
 When `_redo_type` is present it takes precedence over `tags`. Send one or the
 other consistently; sending a `_redo_type` that covers less than the tags do

--- a/redo/docs/guides/integrations/custom-returns-integration.mdx
+++ b/redo/docs/guides/integrations/custom-returns-integration.mdx
@@ -6,8 +6,14 @@ icon: "code"
 
 ## Overview
 
-Sync orders into Redo through our dedicated orders endpoint, so your customers
-get returns and package protection.
+This guide helps you integrate your custom e-commerce platform or order
+management system with Redo by syncing orders through our dedicated orders
+endpoint. This integration allows you to programmatically send order data to
+Redo, enabling seamless returns and package protection for your customers.
+
+Synced orders also feed Redo order tracking. Once you send a fulfillment with
+tracking numbers, Redo tracks the shipment and sends tracking notifications
+according to your Redo settings.
 
 ## When to Use This Integration
 
@@ -86,6 +92,9 @@ returns on unfulfilled items, a line with no fulfillment never appears in the
 return portal. Send a fulfillment once the order ships, and include
 `deliveryDate` if your return window should start at delivery rather than at
 order creation.
+
+Include `trackingNumbers` and `trackingUrls` on the fulfillment — those drive
+order tracking and tracking notifications.
 
 Shipping lines do not affect what is returnable.
 

--- a/redo/docs/guides/integrations/custom-returns-integration.mdx
+++ b/redo/docs/guides/integrations/custom-returns-integration.mdx
@@ -6,8 +6,17 @@ icon: "code"
 
 ## Overview
 
-Sync orders from a custom e-commerce platform, an unsupported platform, or your
-own middleware into Redo, so your customers get returns and package protection.
+Sync orders into Redo through our dedicated orders endpoint, so your customers
+get returns and package protection.
+
+## When to Use This Integration
+
+Use the custom integration orders endpoint when:
+
+- You have a custom-built e-commerce platform
+- Your platform isn't directly supported by Redo
+- You need programmatic control over order synchronization
+- You're building a middleware integration between your systems
 
 ## Integration flow
 

--- a/redo/docs/guides/integrations/custom-returns-integration.mdx
+++ b/redo/docs/guides/integrations/custom-returns-integration.mdx
@@ -330,10 +330,18 @@ other consistently; sending a `_redo_type` that covers less than the tags do
 will under-report the coverage purchased.
 
   <Note>
-  Final sale returns coverage is a **separate** purchase from base returns
-  coverage. When the shopper bought it, add a `__final_sale_coverage` property to
-  the same Redo line item:
+  Final sale returns coverage is billed separately from base returns coverage,
+  so the order payload has to say when the shopper bought it. Add `final sale`
+  alongside `returns`:
   </Note>
+
+```typescript
+tags: ["returns", "final sale"]
+// or
+properties: [{ name: "_redo_type", value: "returns,final sale" }]
+```
+
+An explicit property is also accepted, and wins on its own:
 
 ```typescript
 properties: [
@@ -342,8 +350,10 @@ properties: [
 ]
 ```
 
-Without this property, final sale returns are only applied when your Redo
-settings cover every order.
+Any of these marks the order as final-sale covered **and** as returns covered —
+final sale coverage always implies returns coverage. Without one of them, final
+sale is only applied when your Redo settings cover every order or mark all Redo
+purchases as final sale.
 
 </Accordion>
 


### PR DESCRIPTION
- Fix `_redo_type` example value: `return` -> `returns`
- Document that `_redo_type` takes precedence over `tags`, and that `priceSet` on the Redo line item drives billing
- Document `__final_sale_coverage` for final sale returns coverage
- Add a Package Protection Plus section covering shopper-paid vs merchant-paid/all-orders-covered
- Add a Redo coverage line item to the example request