### PR TITLE
Correct Redo coverage line item docs

### DIFF
--- a/redo/api-schema/openapi.yaml
+++ b/redo/api-schema/openapi.yaml
@@ -1103,11 +1103,19 @@ paths:
         and a complete example payload, see the
         [Custom Returns Integration guide](/docs/guides/integrations/custom-returns-integration).
 
-        Important: If Redo protection is attached to this order, include a line item with:
+        Important: If Redo coverage is attached to this order, include a single
+        coverage line item with:
         - vendor: "re:do"
         - sku: "x-redo"
-        - tags: "returns", "package protection", or "both"
-        - properties: _redo_type with value "return", "package protection", or "both"
+        - priceSet: the full amount the shopper paid for coverage
+        - properties: _redo_type with value "returns", "package protection",
+          "both", or "final sale" (comma-separate to combine, e.g.
+          "returns,package protection")
+        - tags: the same values, read only when _redo_type is absent
+
+        Matching ignores case, and treats spaces, underscores, and hyphens as
+        equivalent, so "Package_Protection" and "package protection" are the same
+        value. A value Redo does not recognize is treated as returns coverage.
       operationId: Custom Order Sync
       parameters:
         - $ref: '#/components/parameters/store-id.param'
@@ -4264,7 +4272,7 @@ components:
           type: array
         tags:
           default: []
-          description: Tags (use "returns", "package protection", or "both" for Redo items)
+          description: Tags. On a Redo coverage line item, use "returns", "package protection", "both", or "final sale". Read only when the `_redo_type` property is absent.
           items:
             type: string
           title: Tags

--- a/redo/api-schema/src/path/custom-order-sync.path.yaml
+++ b/redo/api-schema/src/path/custom-order-sync.path.yaml
@@ -14,11 +14,19 @@ post:
     and a complete example payload, see the
     [Custom Returns Integration guide](/docs/guides/integrations/custom-returns-integration).
 
-    Important: If Redo protection is attached to this order, include a line item with:
+    Important: If Redo coverage is attached to this order, include a single
+    coverage line item with:
     - vendor: "re:do"
     - sku: "x-redo"
-    - tags: "returns", "package protection", or "both"
-    - properties: _redo_type with value "return", "package protection", or "both"
+    - priceSet: the full amount the shopper paid for coverage
+    - properties: _redo_type with value "returns", "package protection",
+      "both", or "final sale" (comma-separate to combine, e.g.
+      "returns,package protection")
+    - tags: the same values, read only when _redo_type is absent
+
+    Matching ignores case, and treats spaces, underscores, and hyphens as
+    equivalent, so "Package_Protection" and "package protection" are the same
+    value. A value Redo does not recognize is treated as returns coverage.
   operationId: Custom Order Sync
   parameters:
     - $ref: "../param/store-id.param.yaml"

--- a/redo/api-schema/src/schema/custom-order/custom-order-line-item.schema.yaml
+++ b/redo/api-schema/src/schema/custom-order/custom-order-line-item.schema.yaml
@@ -58,7 +58,9 @@ properties:
     type: array
   tags:
     default: []
-    description: Tags (use "returns", "package protection", or "both" for Redo items)
+    description: Tags. On a Redo coverage line item, use "returns", "package
+      protection", "both", or "final sale". Read only when the `_redo_type`
+      property is absent.
     items:
       type: string
     title: Tags

--- a/redo/docs/guides/integrations/custom-returns-integration.mdx
+++ b/redo/docs/guides/integrations/custom-returns-integration.mdx
@@ -115,17 +115,28 @@ both — you **must** include a line item with these exact values:
   properties: [
     {
       name: "_redo_type",
-      value: "returns"          // "returns", "package protection", or "both"
+      value: "returns"          // "returns", "package protection", "both", or "final sale"
     }
   ],
   // ... other standard line item fields
 }
 ```
 
-`priceSet` must be the **full** amount the shopper paid for coverage. When one
-line item covers more than one type, send the combined total.
+Send **one** coverage line item per order. When the shopper bought more than one
+kind of coverage, use `"both"` (or a comma-separated value such as
+`"returns,package protection"`) and set `priceSet` to the combined total. If you
+send separate line items instead, each one must carry only the amount the
+shopper paid for that coverage — Redo bills each item on its own.
 
-If both are sent, `_redo_type` wins over `tags`. Keep them in sync.
+`priceSet` must be the **full** amount the shopper paid for coverage.
+
+If both are sent, `_redo_type` wins over `tags` — the tags are ignored entirely,
+not merged. Keep them in sync.
+
+Values are matched case-insensitively, and spaces, underscores, and hyphens are
+interchangeable, so `"Package_Protection"` and `"package protection"` are the
+same value. A value Redo does not recognize is treated as returns coverage, so
+send a recognized value or omit `_redo_type` rather than passing a placeholder.
 
 ### Final sale
 
@@ -135,10 +146,17 @@ When the shopper buys final sale returns coverage, mark it alongside `returns`:
 tags: ["returns", "final sale"]
 // or
 properties: [{ name: "_redo_type", value: "returns,final sale" }]
+// or, alongside any coverage value
+properties: [
+  { name: "_redo_type", value: "returns" },
+  { name: "__final_sale_coverage", value: "true" }
+]
 ```
 
-Final sale coverage always implies returns coverage. Without this, final sale
-only applies if your Redo settings cover every order.
+Final sale coverage always implies returns coverage. Without one of these
+signals, final sale applies only when your Redo settings cover every order or
+treat every Redo purchase as final sale. Final sale coverage also requires
+final sale returns to be enabled for the order's shipping country.
 
 ### Package Protection Plus
 


### PR DESCRIPTION
- Document the full `_redo_type` value set, including `final sale`, and that matching ignores case, spaces, underscores, and hyphens
- Document `__final_sale_coverage` as a final sale signal, and that tags are ignored entirely when `_redo_type` is present
- Say to send one coverage line item, and that separate items are each billed on their own price
- Note that an unrecognized `_redo_type` is treated as returns coverage
- Correct the final sale fallback: it also applies when every Redo purchase is final sale, and requires an enabled shipping country